### PR TITLE
Add EmbryoMetadata stress tests and failure reports

### DIFF
--- a/segmentation_sandbox/stress_tests/README.md
+++ b/segmentation_sandbox/stress_tests/README.md
@@ -1,0 +1,19 @@
+# Stress Tests for `EmbryoMetadata`
+
+Each subfolder contains a Python script that performs a deliberately invalid
+operation on the `EmbryoMetadata` class and captures the resulting error output
+in a Markdown report of the same name.
+
+| Test Folder | Purpose |
+|-------------|---------|
+| `missing_sam_file` | Initialize with a non-existent SAM2 file. |
+| `invalid_sam_json` | Load SAM2 file containing malformed JSON. |
+| `no_experiments_key` | Provide SAM2 JSON missing the required `experiments` key. |
+| `invalid_annotations_dir` | Use an annotations path located in a missing directory. |
+| `ambiguous_parameters` | Call `add_phenotype` with both `embryo_id` and `snip_ids`. |
+| `invalid_phenotype` | Add a phenotype not in the allowed list. |
+| `invalid_target` | Target phenotype addition using an unsupported format. |
+| `existing_output_file` | Running pipeline script with preexisting output aborts instead of updating with new snips. |
+
+These tests are intentionally destructive and are meant to highlight how the
+system fails under misuse. No fixes are implemented.

--- a/segmentation_sandbox/stress_tests/ambiguous_parameters/ambiguous_parameters.md
+++ b/segmentation_sandbox/stress_tests/ambiguous_parameters/ambiguous_parameters.md
@@ -1,0 +1,14 @@
+✅ Loaded configuration from: /workspace/morphseq/segmentation_sandbox/scripts/annotations/config.json
+Creating new annotations from SAM2: /tmp/tmp54o46o9r.json
+❌ ERROR: add_phenotype() called with both approaches:
+   Embryo approach: embryo_id='exp1_e01', target='None'
+   Snip approach: snip_ids=['exp1_e01_s0100']
+   SOLUTION: Use either (embryo_id + target) OR snip_ids, not both
+Caught exception as expected:
+ValueError - Ambiguous parameters: cannot use both embryo and snip approaches
+
+### Summary
+- **Action**: Called `add_phenotype` with both `embryo_id` and `snip_ids`.
+- **Result**: `ValueError` for ambiguous parameter usage.
+- **Cause**: Method prevents simultaneous embryo and snip modes.
+- **Suggested Fix**: Ensure callers use either `embryo_id` with `target` or `snip_ids` exclusively.

--- a/segmentation_sandbox/stress_tests/ambiguous_parameters/run.py
+++ b/segmentation_sandbox/stress_tests/ambiguous_parameters/run.py
@@ -1,0 +1,32 @@
+import os, sys, json, tempfile
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+sam_data = {
+    "experiments": {
+        "exp1": {
+            "videos": {
+                "vid1": {
+                    "images": {
+                        "exp1_vid1_t0100": {"embryos": {"exp1_e01": {}}}
+                    }
+                }
+            }
+        }
+    }
+}
+
+with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    json.dump(sam_data, f)
+    sam_path = f.name
+
+try:
+    metadata = EmbryoMetadata(sam_path)
+    metadata.add_phenotype("NORMAL", "tester", embryo_id="exp1_e01", snip_ids=["exp1_e01_s0100"])
+    print('add_phenotype unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)
+finally:
+    os.remove(sam_path)

--- a/segmentation_sandbox/stress_tests/existing_output_file/existing_output_file.md
+++ b/segmentation_sandbox/stress_tests/existing_output_file/existing_output_file.md
@@ -1,0 +1,25 @@
+First run (create):
+SAM2 input: /workspace/morphseq/segmentation_sandbox/stress_tests/existing_output_file/sam2_annotations.json
+Output path: /workspace/morphseq/segmentation_sandbox/stress_tests/existing_output_file/data/embryo_metadata/sam2_biology.json
+Loading SAM2 data...
+Creating new metadata structure...
+
+Result summary:
+Operation: create
+Embryos: 1
+Total snips: 1
+
+Saved metadata to: /workspace/morphseq/segmentation_sandbox/stress_tests/existing_output_file/data/embryo_metadata/sam2_biology.json
+
+Second run (attempt update without --force):
+SAM2 input: /workspace/morphseq/segmentation_sandbox/stress_tests/existing_output_file/sam2_annotations_v2.json
+Output path: /workspace/morphseq/segmentation_sandbox/stress_tests/existing_output_file/data/embryo_metadata/sam2_biology.json
+Output file exists: /workspace/morphseq/segmentation_sandbox/stress_tests/existing_output_file/data/embryo_metadata/sam2_biology.json
+Use --force to overwrite or --dry-run to preview
+
+
+### Summary
+- **Action**: Ran 07_embryo_metadata_update twice, second time with new SAM2 frame and existing output file.
+- **Result**: Script aborted with message "Output file exists" instead of merging new snips.
+- **Cause**: Early output-file check prevents update mode when annotations JSON already exists.
+- **Suggested Fix**: Provide an update mode that merges new snips instead of exiting.

--- a/segmentation_sandbox/stress_tests/existing_output_file/run.py
+++ b/segmentation_sandbox/stress_tests/existing_output_file/run.py
@@ -1,0 +1,83 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+import shutil
+
+# Paths
+base_dir = Path(__file__).parent
+script_path = base_dir.parents[1] / "scripts" / "pipelines" / "07_embryo_metadata_update.py"
+
+# Clean up from previous runs
+if (base_dir / "data").exists():
+    shutil.rmtree(base_dir / "data")
+
+# Build minimal SAM2 dataset
+sam2_initial = {
+    "experiments": {
+        "exp1": {
+            "videos": {
+                "exp1_A01": {
+                    "images": {
+                        "exp1_A01_t0001": {"embryos": {"exp1_A01_e0001": {}}}
+                    }
+                }
+            }
+        }
+    }
+}
+
+sam2_updated = {
+    "experiments": {
+        "exp1": {
+            "videos": {
+                "exp1_A01": {
+                    "images": {
+                        "exp1_A01_t0001": {"embryos": {"exp1_A01_e0001": {}}},
+                        "exp1_A01_t0002": {"embryos": {"exp1_A01_e0001": {}}}
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Write initial SAM2 file
+sam2_path1 = base_dir / "sam2_annotations.json"
+with open(sam2_path1, "w") as f:
+    json.dump(sam2_initial, f)
+
+# Run script to create metadata
+create = subprocess.run([
+    sys.executable,
+    str(script_path),
+    str(sam2_path1),
+    "--output-dir",
+    str(base_dir),
+], capture_output=True, text=True)
+
+print("First run (create):")
+print(create.stdout, create.stderr, sep="")
+
+# Determine metadata path
+metadata_path = base_dir / "data" / "embryo_metadata" / "sam2_biology.json"
+
+# Write updated SAM2 file with new frame
+sam2_path2 = base_dir / "sam2_annotations_v2.json"
+with open(sam2_path2, "w") as f:
+    json.dump(sam2_updated, f)
+
+# Attempt to update existing metadata without --force
+update = subprocess.run([
+    sys.executable,
+    str(script_path),
+    str(sam2_path2),
+    "--output",
+    metadata_path.name,
+    "--output-dir",
+    str(base_dir),
+], capture_output=True, text=True)
+
+print("Second run (attempt update without --force):")
+print(update.stdout, update.stderr, sep="")
+

--- a/segmentation_sandbox/stress_tests/invalid_annotations_dir/invalid_annotations_dir.md
+++ b/segmentation_sandbox/stress_tests/invalid_annotations_dir/invalid_annotations_dir.md
@@ -1,0 +1,8 @@
+Caught exception as expected:
+FileNotFoundError - Directory for annotations file does not exist: nonexistent_dir
+
+### Summary
+- **Action**: Provided annotations path in a directory that doesn't exist.
+- **Result**: `FileNotFoundError` for missing annotations directory.
+- **Cause**: Code expects directory to pre-exist.
+- **Suggested Fix**: Automatically create directories or prompt user to do so.

--- a/segmentation_sandbox/stress_tests/invalid_annotations_dir/run.py
+++ b/segmentation_sandbox/stress_tests/invalid_annotations_dir/run.py
@@ -1,0 +1,33 @@
+import os, sys, json, tempfile
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+sam_data = {
+    "experiments": {
+        "exp1": {
+            "videos": {
+                "vid1": {
+                    "images": {
+                        "exp1_vid1_t0100": {"embryos": {"exp1_e01": {}}}
+                    }
+                }
+            }
+        }
+    }
+}
+
+with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    json.dump(sam_data, f)
+    sam_path = f.name
+
+invalid_annotations = os.path.join('nonexistent_dir', 'annotations.json')
+
+try:
+    EmbryoMetadata(sam_path, annotations_path=invalid_annotations)
+    print('Initialization unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)
+finally:
+    os.remove(sam_path)

--- a/segmentation_sandbox/stress_tests/invalid_phenotype/invalid_phenotype.md
+++ b/segmentation_sandbox/stress_tests/invalid_phenotype/invalid_phenotype.md
@@ -1,0 +1,12 @@
+✅ Loaded configuration from: /workspace/morphseq/segmentation_sandbox/scripts/annotations/config.json
+Creating new annotations from SAM2: /tmp/tmpw5kxi9a2.json
+❌ ERROR: Invalid phenotype 'NOT_REAL'
+   Valid options: ['NORMAL', 'EDEMA', 'DEAD', 'CONVERGENCE_EXTENSION', 'BLUR', 'CORRUPT']
+Caught exception as expected:
+ValueError - Invalid phenotype 'NOT_REAL'. Valid options: ['NORMAL', 'EDEMA', 'DEAD', 'CONVERGENCE_EXTENSION', 'BLUR', 'CORRUPT']
+
+### Summary
+- **Action**: Used unrecognized phenotype label `NOT_REAL`.
+- **Result**: `ValueError` listing allowed phenotypes.
+- **Cause**: Strict validation against predefined phenotype list.
+- **Suggested Fix**: Expand phenotype list or provide clearer error guidance for custom values.

--- a/segmentation_sandbox/stress_tests/invalid_phenotype/run.py
+++ b/segmentation_sandbox/stress_tests/invalid_phenotype/run.py
@@ -1,0 +1,32 @@
+import os, sys, json, tempfile
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+sam_data = {
+    "experiments": {
+        "exp1": {
+            "videos": {
+                "vid1": {
+                    "images": {
+                        "exp1_vid1_t0100": {"embryos": {"exp1_e01": {}}}
+                    }
+                }
+            }
+        }
+    }
+}
+
+with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    json.dump(sam_data, f)
+    sam_path = f.name
+
+try:
+    metadata = EmbryoMetadata(sam_path)
+    metadata.add_phenotype("NOT_REAL", "tester", embryo_id="exp1_e01", target="all")
+    print('add_phenotype unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)
+finally:
+    os.remove(sam_path)

--- a/segmentation_sandbox/stress_tests/invalid_sam_json/invalid_sam_json.md
+++ b/segmentation_sandbox/stress_tests/invalid_sam_json/invalid_sam_json.md
@@ -1,0 +1,8 @@
+Caught exception as expected:
+ValueError - Invalid JSON in SAM2 file /tmp/tmpz6zfvrxx.json: Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
+
+### Summary
+- **Action**: Loaded `EmbryoMetadata` with malformed JSON file.
+- **Result**: `ValueError` due to JSON parsing failure.
+- **Cause**: SAM2 file contained invalid JSON syntax.
+- **Suggested Fix**: Validate SAM2 files before use and surface clearer error messages to users.

--- a/segmentation_sandbox/stress_tests/invalid_sam_json/run.py
+++ b/segmentation_sandbox/stress_tests/invalid_sam_json/run.py
@@ -1,0 +1,18 @@
+import os, sys, tempfile
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+# Create a temporary file with invalid JSON content
+with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    f.write('{ invalid json }')
+    bad_path = f.name
+
+try:
+    EmbryoMetadata(bad_path)
+    print('Initialization unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)
+finally:
+    os.remove(bad_path)

--- a/segmentation_sandbox/stress_tests/invalid_target/invalid_target.md
+++ b/segmentation_sandbox/stress_tests/invalid_target/invalid_target.md
@@ -1,0 +1,10 @@
+✅ Loaded configuration from: /workspace/morphseq/segmentation_sandbox/scripts/annotations/config.json
+Creating new annotations from SAM2: /tmp/tmp2i8kxny9.json
+Caught exception as expected:
+ValueError - Invalid target format: 'abc'. Use 'all', frame number, or 'start:end' range
+
+### Summary
+- **Action**: Targeted phenotype addition with non-numeric target `abc`.
+- **Result**: `ValueError` for invalid target format.
+- **Cause**: Target must be 'all', numeric frame, or range.
+- **Suggested Fix**: Validate user input before calling `add_phenotype` or extend parser for richer formats.

--- a/segmentation_sandbox/stress_tests/invalid_target/run.py
+++ b/segmentation_sandbox/stress_tests/invalid_target/run.py
@@ -1,0 +1,32 @@
+import os, sys, json, tempfile
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+sam_data = {
+    "experiments": {
+        "exp1": {
+            "videos": {
+                "vid1": {
+                    "images": {
+                        "exp1_vid1_t0100": {"embryos": {"exp1_e01": {}}}
+                    }
+                }
+            }
+        }
+    }
+}
+
+with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    json.dump(sam_data, f)
+    sam_path = f.name
+
+try:
+    metadata = EmbryoMetadata(sam_path)
+    metadata.add_phenotype("NORMAL", "tester", embryo_id="exp1_e01", target="abc")
+    print('add_phenotype unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)
+finally:
+    os.remove(sam_path)

--- a/segmentation_sandbox/stress_tests/missing_sam_file/missing_sam_file.md
+++ b/segmentation_sandbox/stress_tests/missing_sam_file/missing_sam_file.md
@@ -1,0 +1,8 @@
+Caught exception as expected:
+FileNotFoundError - SAM2 file not found: nonexistent_sam2.json
+
+### Summary
+- **Action**: Initialized `EmbryoMetadata` with nonexistent SAM2 file.
+- **Result**: `FileNotFoundError`.
+- **Cause**: Provided SAM2 path does not exist.
+- **Suggested Fix**: Verify SAM2 file path before initialization or handle missing file with user-friendly message.

--- a/segmentation_sandbox/stress_tests/missing_sam_file/run.py
+++ b/segmentation_sandbox/stress_tests/missing_sam_file/run.py
@@ -1,0 +1,12 @@
+import os, sys
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+# Intentionally provide a non-existent SAM2 file path
+try:
+    metadata = EmbryoMetadata('nonexistent_sam2.json')
+    print('Initialization unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)

--- a/segmentation_sandbox/stress_tests/no_experiments_key/no_experiments_key.md
+++ b/segmentation_sandbox/stress_tests/no_experiments_key/no_experiments_key.md
@@ -1,0 +1,8 @@
+Caught exception as expected:
+ValueError - Error reading SAM2 file /tmp/tmpyv21di96.json: Invalid SAM2 format: missing 'experiments' key in /tmp/tmpyv21di96.json
+
+### Summary
+- **Action**: SAM2 file missing the required `experiments` key.
+- **Result**: `ValueError` reporting invalid SAM2 format.
+- **Cause**: Data structure did not meet expected schema.
+- **Suggested Fix**: Ensure SAM2 JSON contains the top-level `experiments` field before processing.

--- a/segmentation_sandbox/stress_tests/no_experiments_key/run.py
+++ b/segmentation_sandbox/stress_tests/no_experiments_key/run.py
@@ -1,0 +1,18 @@
+import os, sys, json, tempfile
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.append(root)
+from segmentation_sandbox.scripts.annotations.embryo_metadata import EmbryoMetadata
+
+sam_data = {"wrong_key": {}}
+with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    json.dump(sam_data, f)
+    bad_path = f.name
+
+try:
+    EmbryoMetadata(bad_path)
+    print('Initialization unexpectedly succeeded')
+except Exception as e:
+    print('Caught exception as expected:')
+    print(type(e).__name__, '-', e)
+finally:
+    os.remove(bad_path)

--- a/segmentation_sandbox/stress_tests/overall_report.md
+++ b/segmentation_sandbox/stress_tests/overall_report.md
@@ -1,0 +1,31 @@
+# EmbryoMetadata Stress Test Report
+
+This document aggregates the failure modes observed while intentionally
+misusing the `EmbryoMetadata` class with dummy SAM2 data. Each test was executed
+separately; detailed output and reproduction steps live alongside the scripts in
+subdirectories of `stress_tests/`.
+
+## Summary of Failures
+
+1. **Missing SAM2 file** – initialization fails with `FileNotFoundError`.
+2. **Malformed SAM2 JSON** – invalid JSON triggers a `ValueError` during parsing.
+3. **Missing `experiments` key** – incorrect SAM2 schema raises a `ValueError`.
+4. **Annotations directory absent** – constructor raises `FileNotFoundError` when annotations path directory is missing.
+5. **Ambiguous `add_phenotype` parameters** – providing both `embryo_id` and `snip_ids` causes a `ValueError`.
+6. **Invalid phenotype label** – unrecognized phenotype triggers a `ValueError` listing allowed options.
+7. **Invalid target format** – non-numeric or malformed targets raise a `ValueError`.
+8. **Existing output file** – pipeline script refuses to update when annotations JSON already exists.
+
+## Observations
+- The class performs early validation on SAM2 inputs, preventing bad data from
+  propagating.
+- Parameter guards in `add_phenotype` are effective at catching ambiguous or
+  unsupported usage patterns.
+- Error messages are generally descriptive, often suggesting corrective action.
+
+## Suggested Improvements
+- Automatically create annotation directories when missing.
+- Provide clearer guidance or examples for target formats.
+- Consider exposing hooks for custom phenotype lists to reduce invalid value
+  errors.
+- Allow the pipeline update script to merge new snips when output files already exist.


### PR DESCRIPTION
## Summary
- add stress_tests folder with scripts that intentionally misuse EmbryoMetadata
- capture error output for missing files, malformed JSON, bad targets, and more
- add test showing pipeline script aborts when metadata file already exists
- relocate stress_tests suite under segmentation_sandbox and update internal paths

## Testing
- `pre-commit run --files segmentation_sandbox/stress_tests/README.md segmentation_sandbox/stress_tests/overall_report.md segmentation_sandbox/stress_tests/missing_sam_file/run.py segmentation_sandbox/stress_tests/missing_sam_file/missing_sam_file.md segmentation_sandbox/stress_tests/invalid_sam_json/run.py segmentation_sandbox/stress_tests/invalid_sam_json/invalid_sam_json.md segmentation_sandbox/stress_tests/no_experiments_key/run.py segmentation_sandbox/stress_tests/no_experiments_key/no_experiments_key.md segmentation_sandbox/stress_tests/invalid_annotations_dir/run.py segmentation_sandbox/stress_tests/invalid_annotations_dir/invalid_annotations_dir.md segmentation_sandbox/stress_tests/ambiguous_parameters/run.py segmentation_sandbox/stress_tests/ambiguous_parameters/ambiguous_parameters.md segmentation_sandbox/stress_tests/invalid_phenotype/run.py segmentation_sandbox/stress_tests/invalid_phenotype/invalid_phenotype.md segmentation_sandbox/stress_tests/invalid_target/run.py segmentation_sandbox/stress_tests/invalid_target/invalid_target.md segmentation_sandbox/stress_tests/existing_output_file/run.py segmentation_sandbox/stress_tests/existing_output_file/existing_output_file.md`

------
https://chatgpt.com/codex/tasks/task_e_68a8adb71ca48332986c33ac24c39ae5