### PR TITLE
Add ROI discovery via OT feature maps infrastructure (Phase 1)

### DIFF
--- a/results/mcolon/20251016/CLASS_IMBALANCE_NOTES.md
+++ b/results/mcolon/20251016/CLASS_IMBALANCE_NOTES.md
@@ -1,0 +1,19 @@
+# Class imbalance handling notes (2025 results)
+
+## Where this was evaluated
+- `results/mcolon/20251014/class_imbalance_method_comparison.py` explicitly compares baseline vs class-imbalance strategies (including `class_weight='balanced'`).
+
+## Current default behavior in the 2025 refactor
+- `predictive_signal_test(..., use_class_weights: bool = True)` defaults to using class weights.
+- When enabled, it sets `class_weight = 'balanced'` and passes that into `LogisticRegression`.
+- `run_analysis.py` wires this through `use_class_weights=config.USE_CLASS_WEIGHTS`.
+- `config.py` sets `USE_CLASS_WEIGHTS = True` by default.
+
+## Source tutorial / routed implementation status
+- In `src/analyze/difference_detection/classification_test_multiclass.py`, the routed API `run_classification_test()` delegates to `run_multiclass_classification_test()`.
+- The underlying classifier factory (`_make_logistic_classifier`) applies `class_weight='balanced'` for both binary and multiclass logistic regression.
+- With `verbose=True`, the implementation now logs the balancing policy and per-bin class counts (so balanced-weight assumptions are explicit during runs).
+
+## Important historical caveat
+- In the older 20251014 `robust_phenotype_emergence_classifaction.py`, `use_class_weights` existed in the signature/docstring, but the model instantiation shown there did not apply `class_weight`.
+- The 20251016 `classification/predictive_test.py` includes an explicit "FIXED" comment indicating the parameter is now actually used.

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PHASE2_5_PLAN.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PHASE2_5_PLAN.md
@@ -1,0 +1,201 @@
+PHASE 2.5 (Research / If Needed) — Learn ROI Masks by Perturbation (Fong/TorchRay-style)
+Goal: Integrate perturbation logic into training (learn m), in a way that is testable, selection-aware, and scalable.
+
+References (inspiration + implementation patterns)
+- Fong & Vedaldi 2017 “Meaningful Perturbations”: optimize a mask to affect a model output under perturbations, with L1/TV + jitter/smoothing to avoid artifacts.  [oai_citation:0‡arXiv](https://arxiv.org/abs/1704.03296?utm_source=chatgpt.com)
+- Fong et al. 2019 “Extremal Perturbations”: smooth masks, area-controlled solutions; TorchRay provides a practical implementation with preserve/delete/dual variants and perturbation operators/pyramid.  [oai_citation:1‡arXiv](https://arxiv.org/pdf/1910.08485?utm_source=chatgpt.com)
+- Fong’s GitHub (older) and TorchRay’s extremal_perturbation.py show concrete design ideas (mask parameterization, perturbation operators, optimization loops).  [oai_citation:2‡GitHub](https://github.com/facebookresearch/TorchRay/blob/master/torchray/attribution/extremal_perturbation.py?utm_source=chatgpt.com)
+
+=====================================================================
+0) Why Phase 2.5 is different (and how they did it)
+=====================================================================
+Fong-style methods typically:
+- fix the model and optimize a mask per-example via gradient descent, using a perturbation (blur/constant) and regularizers (L1/TV).  [oai_citation:3‡arXiv](https://arxiv.org/abs/1704.03296?utm_source=chatgpt.com)
+TorchRay extremal perturbations:
+- optimize a smooth mask (often via a multi-scale/pyramid schedule) and support “preserve”/“delete”/“dual” objective variants with differentiable perturbations.  [oai_citation:4‡GitHub](https://github.com/facebookresearch/TorchRay/blob/master/torchray/attribution/extremal_perturbation.py?utm_source=chatgpt.com)
+
+MorphSeq adaptation:
+- we do NOT want per-image masks (too expensive, brittle).
+- we want a dataset-level ROI (per genotype/time-bin/feature-set): one mask m shared across many embryos.
+
+This is the key scaling choice.
+
+=====================================================================
+1) Phase 2.5 scope decision (critical, pick ONE for Phase 2.5a)
+=====================================================================
+We will implement ONE of these first:
+
+(Option A, recommended first) Learn a GLOBAL mask m for a fixed classifier
+- Freeze trained Phase 1 classifier (w,b) (or retrain once, then freeze).
+- Optimize only m to maximize a perturbation objective.
+- Pros: clean, safe, easy to test; isolates “mask learning” as a module.
+- Cons: m depends on a fixed classifier; might miss alternate decision boundaries.
+
+(Option B) Jointly learn classifier + mask (w,b,m) end-to-end
+- Pros: can find a better combined solution.
+- Cons: more failure modes; easier to “cheat” (co-adaptation); harder to interpret.
+
+Phase 2.5a should be Option A.
+
+=====================================================================
+2) Mask parameterization (JAX-friendly and stable)
+=====================================================================
+We learn m_low at low resolution (learn_res=128), then upsample to 512.
+- m_param ∈ R^(learn_res, learn_res), unconstrained
+- m = sigmoid(m_param / τ) ∈ (0,1)
+- m_full = upsample(m → 512×512), then multiply by mask_ref
+
+Why:
+- TorchRay and Fong both lean on smoothness/low-res to avoid brittle pixel artifacts.  [oai_citation:5‡arXiv](https://arxiv.org/pdf/1910.08485?utm_source=chatgpt.com)
+- Low-res mask is also a compute win (huge for nulls / bootstraps).
+
+Binary masks are deferred; we keep soft masks in training for differentiability.
+
+=====================================================================
+3) Perturbation operator (must be differentiable)
+=====================================================================
+Use the same semantics you already defined (preserve mask):
+- P(X, m) = m*X + (1-m)*B
+
+Baseline B:
+- constant WT-only spatial mean baseline (fold-safe) from Phase 2.0
+- Phase 2.1 blur baseline remains useful later, but Phase 2.5a uses constant first
+
+TorchRay uses blur perturbations frequently for “naturalistic” occlusion; we can add later.  [oai_citation:6‡Facebook Research](https://facebookresearch.github.io/TorchRay/attribution.html?utm_source=chatgpt.com)
+
+=====================================================================
+4) Objective (what we optimize for)
+=====================================================================
+We define a scalar “score” S(X) to optimize under perturbation.
+In your setting, S can be:
+- mean logit for mutant class (or logit gap mutant-WT), consistent with Phase 2.0
+
+Two canonical games:
+Deletion game (learn necessary region)
+- Want deletion to hurt: maximize drop in score when ROI is deleted
+- Equivalent: maximize S(X) - S(P(X, 1-m))
+Preservation game (learn sufficient region)
+- Want preserved ROI to keep score: maximize S(P(X, m))
+
+Dual game (recommended; TorchRay supports variants like this conceptually)
+- maximize: S(P(X, m)) - S(P(X, 1-m))
+This directly matches your “inside better than outside” principle.
+
+Regularization on m (same spirit as Phase 1)
+- λ * ||m||_1  (area control)
+- μ * TV(m)    (contiguity)
+Optionally add:
+- entropy penalty to avoid mushy masks early: η * mean(m*(1-m))
+
+This is directly in the Fong lineage: perturbation objective + L1/TV to get compact smooth regions.  [oai_citation:7‡arXiv](https://arxiv.org/abs/1704.03296?utm_source=chatgpt.com)
+
+=====================================================================
+5) Safety rails (avoid “mask cheating” and unstable artifacts)
+=====================================================================
+Borrowed from the Fong concerns about masks exploiting model artifacts:
+- Jitter: random small spatial shifts of the mask (or perturbation alignment) each step so mask cannot overfit exact pixel grid quirks.  [oai_citation:8‡openaccess.thecvf.com](https://openaccess.thecvf.com/content_ICCV_2017/papers/Fong_Interpretable_Explanations_of_ICCV_2017_paper.pdf?utm_source=chatgpt.com)
+- Smooth mask: enforce TV and/or learn at low-res then upsample (already planned).
+- Fold-safety: baseline computed only from training fold, mask trained only on training fold.
+- Selection-aware inference: treat mask hyperparameters (λ,μ,τ) as selected; nulls must repeat selection.
+
+All of these are about making the perturbation meaningful rather than adversarial.
+
+=====================================================================
+6) Training loop architecture (DRY/KISS in MorphSeq)
+=====================================================================
+Modules (new in Phase 2.5; Phase 2.0 code remains additive)
+- roi_mask_param.py
+    - MaskParam (m_param → m_low → m_full)
+    - tv(m_low) with mask_ref downsampled to learn_res
+    - mask jitter utility
+- roi_mask_objective.py
+    - compute_score(logits or logit-gap)
+    - apply_perturbation(X, m_full, baseline)
+    - objective variants: delete/preserve/dual
+- roi_mask_trainer.py
+    - train_mask_fixed_model(...)
+    - optional: train_mask_and_model_joint(...), deferred
+
+Key reuse:
+- compute_logits(X, w_full, b) shared utility (Phase 1/2 already needed)
+- baseline computation (roi_perturbation.py) reused
+
+=====================================================================
+7) Scaling plan (what will actually scale)
+=====================================================================
+We train ONE mask per “unit of analysis”:
+- per genotype comparison + per feature-set + per stage-bin (if you later stage-bin)
+Not per embryo, not per snip.
+
+Compute:
+- Each step requires computing logits on:
+  - X_orig (maybe optional)
+  - X_delete
+  - X_preserve
+You can avoid X_orig in dual objective.
+
+Batching:
+- minibatch over embryos/snips with group-aware sampling
+- low-res mask makes gradients cheap; upsampling is cheap
+- keep X on-disk chunked by N; stream batches (Zarr)
+
+Backends:
+- JAX jit for the step, run sequential batches
+- GPU helps for large N, but CPU jit can still be fine; treat as engineering detail
+
+=====================================================================
+8) Testing strategy (must be done before real data)
+=====================================================================
+T0: Synthetic planted-ROI test (required)
+- Generate X with a known ROI where only that region carries signal
+- Verify learned mask recovers ROI and that dual objective improves
+
+T1: Regression test vs Phase 2.0 occlusion
+- Using Phase 1 ROI, Phase 2.0 should show Δ_delete > Δ_preserve
+- Phase 2.5 learned mask should show stronger (or at least consistent) gap
+
+T2: Stability tests
+- Fixed hyperparams bootstrap (OOB) for learned mask: IoU + gap CI
+- Sensitivity to quantile thresholding (if you binarize for reporting)
+
+=====================================================================
+9) Inference / Nulls for Phase 2.5 (selection-aware by design)
+=====================================================================
+Because we are learning m, hyperparameter selection matters even more.
+Minimum required:
+- Embryo-level label permutation null:
+  - rerun mask training with permuted labels (or permuted score assignment)
+  - record best achieved dual-gap under same training budget
+This is expensive; mitigation:
+- learn at 128²
+- cap steps (early stopping)
+- small hyperparam grid in Phase 2.5a
+
+Bootstrap:
+- OOB bootstrap fixed hyperparams:
+  - fit mask on inbag
+  - evaluate gap on OOB
+
+=====================================================================
+10) Phase 2.5a “Done” definition
+=====================================================================
+- Implement Option A: learn mask m with fixed classifier
+- Dual objective + L1/TV + low-res + jitter
+- Synthetic planted-ROI test passes
+- On cep290 pilot: learned m produces Δ_delete > Δ_preserve with OOB bootstrap CI
+- Artifacts saved (mask maps, training curves, summary JSON, plots)
+
+=====================================================================
+11) Practical staging (what to do first)
+=====================================================================
+Phase 2.5a (Week 1–2 equivalent)
+1) Implement MaskParam + TV + jitter at learn_res=128
+2) Implement dual objective with fixed (w,b), constant baseline
+3) Add trainer with minibatch streaming
+4) Add synthetic planted-ROI test + one real small cep290 run
+5) Only then consider adding blur baseline (Phase 2.1) into objective
+
+Deferred:
+- joint learning of (w,m)
+- multi-scale / pyramid schedules (TorchRay-style) unless needed
+- blur/noise perturbations as defaults (keep constant first)

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PHASE2_ADDENDUM_PLAN.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PHASE2_ADDENDUM_PLAN.md
@@ -1,0 +1,154 @@
+ADDENDUM: Phase 2 Occlusion Validation Plan
+Incorporating “ASSESSMENT: Phase 2 Counterfactual Occlusion Validation Plan vs PR #9”
+Date: 2026-02-15
+
+This addendum updates the Phase 2 plan with concrete integration fixes and risk mitigations identified in the assessment. It is still Phase 2.0-only (validation, no mask learning) and remains additive to PR #9.
+
+============================================================
+A) REQUIRED INTEGRATION FIXES (Phase 1 / PR #9 alignment)
+============================================================
+
+A1) Fix driver import bug (PR #9)
+- Problem: run_roi_discovery.py imports ROIRunConfig from roi_config, but ROIRunConfig is commented out → ImportError.
+- Action:
+  [ ] Either (preferred) re-enable ROIRunConfig in roi_config.py and keep it as the single config surface
+  [ ] OR remove the import and use explicit args until ROIRunConfig is wired
+
+A2) Add channel ordering / names to TrainResult (required for Phase 2)
+- Problem: Phase 2 needs channel_names/channel_schema to apply baseline policies deterministically.
+- Action:
+  [ ] Add channel_names (tuple[str]) to TrainResult.config (or TrainResult as a field)
+  [ ] Source of truth: FeatureDataset manifest channel_schema
+  [ ] Pass through from loader → trainer → TrainResult
+
+A3) Extract shared compute_logits() utility (avoid drift)
+- Problem: logit computation duplicated in roi_sweep.py; Phase 2 would add another copy.
+- Action:
+  [ ] Create compute_logits(X, w_full, b) -> (N,) in roi_trainer.py or a small roi_utils.py
+  [ ] Replace all inlined logits computations with this utility (Phase 1 + Phase 2)
+
+A4) Bootstrap resampling helper (reduce duplication)
+- Phase 1 bootstrap loop differs from Phase 2 OOB bootstrap loop; both are group-aware and similar.
+- Action:
+  [ ] Create a group-aware resampling helper (e.g., iter_bootstrap_groups(groups, y, stratify=True)) that yields:
+      - inbag_group_ids
+      - oob_group_ids
+      - flags for empty/degenerate OOB
+  [ ] Phase 2 uses it for OOB evaluation; Phase 1 can optionally keep its current loop
+
+============================================================
+B) PHASE 2.0 COMMITMENTS (tightened)
+============================================================
+
+B1) Bootstrap strategy: FIXED (λ*, μ*) + true OOB evaluation
+- Commit: Phase 2 bootstrap_occlusion trains at fixed selected (λ*,μ*) and evaluates on OOB embryos only.
+- This answers “is THIS ROI stable?” and is cheaper and more interpretable than a full-sweep bootstrap.
+
+B2) Baseline fold-safety
+- Baselines MUST be computed from train/inbag data only for any reported metric.
+- “Full dataset sanity check” is allowed only as a diagnostic:
+  - Must log WARNING: baseline computed from full dataset (leakage) and results are non-inferential.
+
+B3) Primary metric: logit-gap difference (bootstrap target)
+- Primary reported statistic per replicate:
+  - observed_gap_b = mean_i[(z_orig - z_delete) - (z_orig - z_preserve)] on OOB
+- Secondary (report-only unless later requested): AUROC deltas
+
+B4) Phase 2.0 baseline policy (avoid scope creep)
+- Implement baseline_policy plumbing, but default ALL channels to "spatial" for Phase 2.0.
+- Defer per-channel customization to Phase 2.1 unless a concrete failure mode appears.
+
+============================================================
+C) EDGE CASES (must be handled explicitly)
+============================================================
+
+C1) OOB set degeneracy
+- In some bootstrap replicates, OOB may be empty OR contain only one class.
+- Rules:
+  - If OOB empty → skip replicate, log
+  - If OOB single-class:
+      - logit gaps still computed and used for observed_gap_b
+      - AUROC metrics are undefined → set NaN, log
+
+C2) ROI threshold sensitivity (cheap but important)
+- Phase 2 results depend on quantile threshold q used in extract_roi().
+- Requirement:
+  - Run Phase 2.0 at Phase 1 default q first
+  - Add a quick sensitivity report for q ∈ {0.85, 0.90, 0.95}
+  - This requires no retraining if ROI is re-thresholded from w_full, but in Phase 2 bootstrap the ROI is extracted per replicate anyway:
+      - implement threshold sweep inside evaluation step (cheap), or run 3 passes of evaluation using same bootstraps
+
+C3) Small-N power expectation
+- Add a pre-flight diagnostic:
+  - estimate “expected gap scale” from Phase 1 weights inside vs outside ROI on training set
+  - if predicted gap is comparable to noise, mark Phase 2 as potentially inconclusive a priori
+- This is a warning flag, not a blocker.
+
+============================================================
+D) UPDATED PHASE 2.0 IMPLEMENTATION SEQUENCE
+============================================================
+
+Week 0 (pre-Phase 2 coding; must do)
+  [ ] Fix ROIRunConfig import bug in run_roi_discovery.py
+  [ ] Extract compute_logits() utility and use it in Phase 1 call sites
+  [ ] Ensure TrainResult carries channel_names (from FeatureDataset manifest)
+
+Week 1: roi_perturbation.py (NEW)
+  - Baseline computation:
+      constant spatial baseline from TRAIN only (WT-only default)
+  - Perturbation operator:
+      P(X,m) = m*X + (1-m)*B
+  - Strict shape/mask checks + unit tests
+  - (optional) group-resampling helper added here if convenient
+
+Week 2: roi_occlusion.py (NEW)
+  - evaluate_occlusion():
+      compute z_orig, z_delete, z_preserve via compute_logits()
+      output per-sample gaps + observed_gap
+      compute AUROC deltas if both classes present (else NaN)
+  - bootstrap_occlusion():
+      OOB bootstrap loop at fixed (λ*, μ*)
+      baseline fit on inbag only
+      OOB evaluation only
+      handle empty/single-class OOB cases
+      store bootstrap_gaps, CI, frac_positive
+
+Week 3: integration + config surface
+  - Prefer enabling ROIRunConfig (single config object) to avoid fit() kwargs explosion
+  - Add occlusion section to run artifacts:
+      occlusion_config.json
+      occlusion_summary.json
+      bootstrap_gaps.npy
+      plots/
+  - Add baseline leakage warning for optional diagnostic full-dataset sanity eval
+
+Week 4: validation
+  - Synthetic planted-ROI smoke test (required before real data):
+      create a toy dataset with a known ROI → verify Δ_delete > Δ_preserve
+  - Real cep290 run:
+      run Phase 2.0 default q
+      run threshold sensitivity q ∈ {0.85, 0.90, 0.95}
+  - If displacement channels look weak under constant baseline:
+      queue Phase 2.1 blur baseline (not required for Phase 2.0 completion)
+
+============================================================
+E) PHASE 2.0 “DONE” DEFINITION (unchanged, but sharper)
+============================================================
+
+Phase 2.0 is DONE when:
+- Occlusion preserve/delete evaluation works end-to-end
+- Primary metric (logit-gap difference) has OOB bootstrap CI
+- Degenerate OOB cases are handled and logged
+- Artifacts saved in standard run directory
+- Threshold sensitivity report is generated (q ∈ {0.85,0.90,0.95})
+- No API/config sprawl: configuration is centralized (prefer ROIRunConfig)
+
+============================================================
+F) NOTES ON “COMPUTATIONAL STABILITY” VS “BIOLOGY-DEPENDENT” TUNING
+============================================================
+
+We explicitly do NOT claim a universal optimal (λ,μ,q).
+Instead, we will:
+- maintain “computationally stable defaults” (learn_res=128, modest λ/μ grid, default q)
+- log sweep behavior and runtime scaling as part of run artifacts
+- treat parameter sweeps as biology-dependent discovery, documented per dataset/phenotype

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PLAN.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PLAN.md
@@ -1,0 +1,234 @@
+# Implementation Plan (MorphSeq) — ROI Discovery via WT-Referenced OT Feature Maps
+
+**(Updated: Phase 1 commits to FIXED (λ,μ) bootstrap; removes compare(); clarifies "computationally stable" vs "biology-dependent" tuning)**
+
+## Purpose
+
+- Learn contiguous, interpretable regions of importance (ROIs) on a 512×512 canonical embryo grid that explain genotype discriminability (WT vs cep290) using OT-derived template-space feature maps.
+- Build a scalable backend for large datasets and a simple, biologist-friendly front end.
+- Ensure statistical validity via selection-aware null distributions and stability resampling.
+- Explicitly separate:
+  - **(A)** computationally stable defaults (robust + fast to run)
+  - **(B)** biology-dependent tuning (signal-to-noise, phenotype type, dataset size)
+
+## Inspiration (principles, not full reproduction)
+
+- Fong & Vedaldi 2017 "Meaningful Perturbations":
+  https://arxiv.org/pdf/1704.03296
+- Fong et al. 2019 "Extremal Perturbations":
+  https://arxiv.org/abs/1910.08485
+
+## Core Model (Linear, small-sample friendly; ROI from weights)
+
+- Weight-map regularized logistic regression:
+
+      J(w,b) = logistic_loss(y, <w, X> + b) + λ||w||_1 + μ TV(w)
+
+- ROI derived from |w| after training (quantile threshold default).
+- TV neighborhood: 4-neighborhood restricted to valid in-mask edges (no padding outside embryo).
+
+## Scaling Pattern (default)
+
+- Learn w_low at low resolution; upsample inside the model:
+  - learn_res=128 (default), optional 256 later
+  - output_res=512 always (canonical)
+  - penalties (L1, TV) applied in low-res space
+
+---
+
+## A) DATA CONTRACT (finalize before model code)
+
+### FeatureDataset = standardized on-disk source of truth
+
+**Format:** Zarr (arrays) + Parquet (metadata) + JSON manifest (provenance + rules)
+
+### Directory
+
+    results/<date>/roi_feature_dataset_<tag>/
+      manifest.json
+      metadata.parquet
+      features.zarr/
+        X/            (N, 512, 512, C) float32
+        y/            (N,) int {0,1}
+        mask_ref/     (512,512) bool/uint8
+        qc/
+          total_cost_C/    (N,) float32
+          outlier_flag/    (N,) bool
+
+### Manifest (must include; hard validation)
+
+- canonical_grid: 512×512
+- channel_schema: names + definitions + units
+- QC rules:
+  - IQR outlier filter on total_cost_C (1.5×IQR), logged, never deleted
+- split_policy:
+  - group_key = embryo_id (MANDATORY; prevents leakage)
+- class_balance_strategy (MANDATORY; declared here):
+  - use existing MorphSeq "balance method" already used in prior classification models
+  - weights computed from TRAIN fold only (recommended)
+- chunking/compression spec for X
+
+---
+
+## B) DATA INGESTION (streamable + deterministic)
+
+- Chunk X along N; keep 512×512 tiles contiguous:
+  chunk (8,512,512,C) or (16,512,512,C)
+- Loader supports full-batch (small N) and minibatch (large N).
+- Filtering is deterministic via qc/outlier_flag (default exclude; never drop silently).
+- CV splits grouped by embryo_id; fold-local class weights (from training fold only).
+
+---
+
+## C) TV DEFINITION (explicit boundary behavior)
+
+- TV defined over edges; include edge (p,q) only if p and q are inside mask_ref.
+- No zero-padding outside embryo.
+- Boundary pixels therefore have fewer valid neighbors ("reduced-degree boundary").
+- Diagnostics:
+  - report boundary_fraction of ROI (ROI overlap with thin boundary band) to detect registration-driven edge artifacts.
+- Optional later: TV normalization by edge count if mask geometry varies across datasets; not required in Phase 1.
+
+---
+
+## D) MODEL TRAINING (JAX backend)
+
+### Requirements
+
+- JAX + Optax; jit train_step
+- objective logs must include raw + weighted components:
+  - logistic_loss_raw
+  - l1_raw, tv_raw
+  - l1_weighted=λ*l1_raw, tv_weighted=μ*tv_raw
+  - total_objective
+  - class_weights used
+
+### Default training mode
+
+- params: w_low (learn_res×learn_res×C), b
+- w_full = bilinear_upsample(w_low → 512×512×C)
+- logits: <X, w_full> + b
+- loss: class-weighted logistic + λL1(w_low) + μTV(w_low)
+
+---
+
+## E) λ/μ SWEEP + DETERMINISTIC SELECTION
+
+### Important nuance (explicit)
+
+- There is no universal "perfect (λ,μ)".
+- (λ,μ) depends on:
+  - phenotype type + expected spatial scale
+  - signal-to-noise and sample size
+  - feature channel choice (cost vs displacement vs div vs Δm)
+- Therefore we treat sweeps as discovery + documentation, not one-time "solve and forget".
+
+### Phase 1: minimal sweep for a stable starting point
+
+- Coarse λ×μ grid (small) to identify a sensible region of operation.
+- Deterministic selection rule (pick one and log):
+  - **Option A (recommended):** knee on Pareto front (AUROC vs complexity)
+  - **Option B:** smallest complexity within ε of best AUROC
+
+### Complexity metrics (recorded for selection + reporting)
+
+- area_fraction, n_components, boundary_fraction
+
+### Outputs
+
+- Store the full sweep table and the selected (λ,μ) with selection score and rule parameters (beta/ε).
+- These become "notes" for future biology-specific runs.
+
+---
+
+## F) NULLS + STABILITY (Phase 1 commitment)
+
+### NULL 1 (required): label permutation significance (selection-aware)
+
+- Permute labels at embryo_id unit.
+- For each permuted run:
+  - run the same sweep + same deterministic selection rule
+  - record selected AUROC (and optionally max across sweep)
+- p-value computed against the selection-aware null.
+
+### NULL 3 (required): bootstrap stability at FIXED (λ,μ)
+
+**Phase 1 commitment:** bootstrap uses the selected (λ,μ) fixed.
+
+**Reason:**
+- answers the interpretable question "is THIS ROI stable?"
+- cheaper and more scalable than full-sweep bootstrap
+- supports quick iteration and easier debugging
+
+### Bootstrap protocol
+
+- Resample embryos with replacement within each class.
+- Fit model at fixed (λ,μ), same learn_res.
+- Extract ROI via fixed thresholding rule (quantile q) and compute:
+  - IoU distribution across bootstrap ROIs
+  - variability of ROI area/components/boundary_fraction
+- Report stability summary alongside AUROC and permutation p-value.
+
+### Deferred upgrade (Phase 2 / if needed)
+
+- full-sweep bootstrap ("is the selection procedure stable?") — optional later.
+
+### NULL 2 (spatial structured null)
+
+- Deprioritized; revisit only if reviewers demand.
+
+---
+
+## G) BIOLOGIST-FACING FRONT END (scope-limited for Phase 1)
+
+### Phase 1 API (minimal; no compare())
+
+```python
+morphseq.roi.fit(
+    genotype="cep290",
+    features="cost" | "cost+disp" | "all_ot",
+    learn_res=128|256,
+    roi_size="small|medium|large",      # maps to λ grid presets
+    smoothness="low|medium|high",       # maps to μ grid presets
+    class_balance="morphseq_balance_method",
+    null="permute|bootstrap|both|none",
+    n_permute=100, n_boot=200,
+    out_dir=...,
+)
+
+morphseq.roi.plot(run_id, style="filled_contours", overlays=["outline", "optional_S_isolines"])
+morphseq.roi.report(run_id)  # -> AUROC, selected (λ,μ), area/components, permutation p, bootstrap IoU, boundary_fraction
+```
+
+- Optional diagnostic overlay: S isolines (not required for core ROI training)
+
+---
+
+## Immediate next actions (ready to build)
+
+1. **Build FeatureDataset builder + validator (contract-first)**
+   - Write Zarr/Parquet/manifest including QC rules, split policy, class_balance_strategy.
+   - Implement fail-fast schema checks with informative errors.
+
+2. **Implement streaming loader**
+   - Deterministic filtering, embryo-grouped CV splits, fold-local class weights.
+
+3. **Implement JAX trainer (learn_res=128 default)**
+   - Weighted logistic + λL1 + μTV with explicit TV boundary rule.
+   - Store raw + weighted objective terms and class weights.
+
+4. **Implement small λ×μ sweep + deterministic selection**
+   - Log Pareto set + knee/ε selection metadata.
+   - Export sweep table and selected (λ,μ).
+
+5. **Implement NULL 1 permutation (selection-aware) + NULL 3 bootstrap (fixed λ/μ)**
+   - Parallel, resume-safe artifacts.
+   - Report p-value and bootstrap IoU.
+
+## Definition of "done" (Phase 1)
+
+- Validated, streamable FeatureDataset
+- Reproducible sweep with deterministic selection and documented (λ,μ) behavior
+- Selection-aware permutation p-value
+- Fixed-(λ,μ) bootstrap ROI stability (IoU + ROI complexity diagnostics)
+- Minimal front end that a non-coder can run and interpret

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/README.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/README.md
@@ -18,11 +18,19 @@ trained at low resolution (128x128) and upsampled to canonical 512x512.
 20260215_roi_discovery_via_ot_feature_maps/
 ├── PLAN.md                          # Full implementation plan
 ├── README.md                        # This file
+├── PHASE2_ADDENDUM_PLAN.md          # Phase 2.0 occlusion validation addendum
+├── PHASE2_5_PLAN.md                 # Phase 2.5 learned-mask plan
 ├── roi_config.py                    # Configuration dataclasses
 ├── roi_feature_dataset.py           # FeatureDataset builder + validator
 ├── roi_loader.py                    # Streaming loader with grouped CV splits
 ├── roi_tv.py                        # Total Variation with mask-aware boundaries
 ├── roi_trainer.py                   # JAX trainer (logistic + L1 + TV)
+├── roi_resampling.py                # Group-aware bootstrap/OOB helpers
+├── roi_perturbation.py              # Phase 2 perturbation + fold-safe baseline
+├── roi_occlusion.py                 # Phase 2 OOB occlusion evaluation
+├── roi_mask_param.py                # Phase 2.5 mask parameterization utilities
+├── roi_mask_objective.py            # Phase 2.5 perturbation objectives
+├── roi_mask_trainer.py              # Phase 2.5 fixed-model mask trainer
 ├── roi_sweep.py                     # λ/μ sweep + deterministic selection
 ├── roi_nulls.py                     # Permutation null + bootstrap stability
 ├── roi_viz.py                       # Visualization (weight maps, ROI overlays, null plots)

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/README.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/README.md
@@ -1,0 +1,76 @@
+# ROI Discovery via WT-Referenced OT Feature Maps
+
+This directory contains the Phase 1 implementation of ROI (Region of Interest)
+discovery using optimal transport feature maps on the 512x512 canonical embryo grid.
+
+## Overview
+
+The pipeline learns contiguous, interpretable spatial regions that explain
+genotype discriminability (WT vs cep290) using OT-derived template-space
+feature maps (cost, displacement, divergence, mass change).
+
+**Core model:** Weight-map regularized logistic regression with L1 + TV penalty,
+trained at low resolution (128x128) and upsampled to canonical 512x512.
+
+## Directory Structure
+
+```
+20260215_roi_discovery_via_ot_feature_maps/
+├── PLAN.md                          # Full implementation plan
+├── README.md                        # This file
+├── roi_config.py                    # Configuration dataclasses
+├── roi_feature_dataset.py           # FeatureDataset builder + validator
+├── roi_loader.py                    # Streaming loader with grouped CV splits
+├── roi_tv.py                        # Total Variation with mask-aware boundaries
+├── roi_trainer.py                   # JAX trainer (logistic + L1 + TV)
+├── roi_sweep.py                     # λ/μ sweep + deterministic selection
+├── roi_nulls.py                     # Permutation null + bootstrap stability
+├── roi_viz.py                       # Visualization (weight maps, ROI overlays, null plots)
+├── roi_api.py                       # Biologist-facing API (fit / plot / report)
+└── run_roi_discovery.py             # Example driver script
+```
+
+## Quick Start
+
+```bash
+# From morphseq root
+cd results/mcolon/20260215_roi_discovery_via_ot_feature_maps
+
+# 1) Build a FeatureDataset from existing OT results
+python roi_feature_dataset.py --build \
+    --ot-results-dir <path_to_ot_pair_outputs> \
+    --out-dir roi_feature_dataset_cep290
+
+# 2) Run ROI discovery with defaults
+python run_roi_discovery.py
+
+# 3) Or use the API from a notebook/script:
+#    from roi_api import fit, plot, report
+#    result = fit(genotype="cep290", features="cost")
+#    plot(result.run_id)
+#    report(result.run_id)
+```
+
+## Integration with Existing MorphSeq Code
+
+- **OT backend:** Uses `src/analyze/utils/optimal_transport/` (UOTConfig, transport_maps)
+- **Classification patterns:** Mirrors `src/analyze/difference_detection/` (balanced LogisticRegression, permutation testing, PermutationResult)
+- **Canonical grid:** Outputs live on the 512x512 canonical grid from `src/analyze/optimal_transport_morphometrics/uot_masks/uot_grid.py`
+- **Class balancing:** Uses sklearn `class_weight='balanced'` consistent with existing classification code
+- **Parquet storage:** Follows the schema patterns in `feature_compaction/storage.py`
+
+## Dependencies
+
+- JAX + Optax (for GPU-accelerated training)
+- zarr (for chunked feature storage)
+- pandas, pyarrow (for metadata/Parquet)
+- scikit-learn (for class weights, AUROC)
+- scipy (for spatial operations)
+- matplotlib (for visualization)
+
+## References
+
+- See PLAN.md for the full implementation plan
+- See `src/analyze/utils/optimal_transport/` for OT infrastructure
+- See `src/analyze/difference_detection/` for classification/permutation patterns
+- See `results/mcolon/20260121_uot-mvp/` for UOT MVP that produces input data

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_api.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_api.py
@@ -1,0 +1,395 @@
+"""
+Biologist-facing API for ROI discovery.
+
+Phase 1 API (minimal; no compare()):
+    fit()  — run full pipeline (sweep + nulls)
+    plot() — visualize ROI results
+    report() — print summary statistics
+
+Follows the front-end pattern from PLAN.md Section G.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from roi_config import (
+    LAMBDA_PRESETS,
+    MU_PRESETS,
+    FeatureSet,
+    NullConfig,
+    NullMode,
+    ROIRunConfig,
+    ROISizePreset,
+    SmoothnessPreset,
+    SweepConfig,
+    TrainerConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def fit(
+    dataset_dir: str,
+    genotype: str = "cep290",
+    features: str = "cost",
+    learn_res: int = 128,
+    roi_size: str = "medium",
+    smoothness: str = "medium",
+    class_balance: str = "morphseq_balance_method",
+    null: str = "both",
+    n_permute: int = 100,
+    n_boot: int = 200,
+    out_dir: Optional[str] = None,
+    random_seed: int = 42,
+) -> Dict:
+    """
+    Run ROI discovery pipeline end-to-end.
+
+    Parameters
+    ----------
+    dataset_dir : str
+        Path to validated FeatureDataset directory.
+    genotype : str
+        Target genotype to compare against WT.
+    features : str
+        "cost", "cost+disp", or "all_ot".
+    learn_res : int
+        Resolution for weight learning (128 or 256).
+    roi_size : str
+        "small", "medium", or "large" — maps to λ presets.
+    smoothness : str
+        "low", "medium", or "high" — maps to μ presets.
+    class_balance : str
+        Balance method (only "morphseq_balance_method" supported).
+    null : str
+        "permute", "bootstrap", "both", or "none".
+    n_permute : int
+        Number of permutations for NULL 1.
+    n_boot : int
+        Number of bootstrap iterations for NULL 3.
+    out_dir : str, optional
+        Output directory. Auto-generated if None.
+    random_seed : int
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    dict with keys:
+        run_id, out_dir, sweep_result, nulls_result, config
+    """
+    from roi_loader import FeatureLoader
+    from roi_sweep import run_sweep, save_sweep_result
+    from roi_nulls import run_nulls, save_nulls_result
+
+    # Resolve config
+    roi_size_enum = ROISizePreset(roi_size)
+    smoothness_enum = SmoothnessPreset(smoothness)
+    null_mode = NullMode(null)
+
+    lambda_values = list(LAMBDA_PRESETS[roi_size_enum])
+    mu_values = list(MU_PRESETS[smoothness_enum])
+
+    trainer_config = TrainerConfig(
+        learn_res=learn_res,
+        random_seed=random_seed,
+    )
+    sweep_config = SweepConfig(
+        lambda_values=tuple(lambda_values),
+        mu_values=tuple(mu_values),
+    )
+    null_config = NullConfig(
+        null_mode=null_mode,
+        n_permute=n_permute,
+        n_boot=n_boot,
+        random_seed=random_seed,
+    )
+
+    # Generate run_id
+    import hashlib
+    import time
+    run_id = hashlib.md5(
+        f"{genotype}_{features}_{learn_res}_{roi_size}_{smoothness}_{time.time()}".encode()
+    ).hexdigest()[:12]
+
+    if out_dir is None:
+        out_dir = str(Path(dataset_dir).parent / f"roi_run_{run_id}")
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"ROI discovery run: {run_id}")
+    logger.info(f"  genotype={genotype}, features={features}")
+    logger.info(f"  learn_res={learn_res}, roi_size={roi_size}, smoothness={smoothness}")
+    logger.info(f"  null={null}, n_permute={n_permute}, n_boot={n_boot}")
+
+    # Load data
+    loader = FeatureLoader(dataset_dir)
+    X, y, groups = loader.load_full()
+    mask_ref = loader.load_mask_ref()
+
+    logger.info(f"  Loaded: {X.shape[0]} samples, {X.shape[-1]} channels")
+
+    # 1) Sweep
+    logger.info("Step 1: λ/μ sweep...")
+    sweep_result = run_sweep(
+        X, y, mask_ref, groups,
+        lambda_values=lambda_values,
+        mu_values=mu_values,
+        sweep_config=sweep_config,
+        trainer_config=trainer_config,
+    )
+    save_sweep_result(sweep_result, out_path / "sweep")
+
+    # 2) Nulls
+    nulls_result = None
+    if null_mode != NullMode.NONE:
+        logger.info("Step 2: Null testing...")
+        nulls_result = run_nulls(
+            X, y, mask_ref, groups,
+            observed_auroc=sweep_result.selected_auroc,
+            selected_lam=sweep_result.selected_lam,
+            selected_mu=sweep_result.selected_mu,
+            selection_rule=sweep_result.selection_rule,
+            lambda_values=lambda_values,
+            mu_values=mu_values,
+            null_config=null_config,
+            sweep_config=sweep_config,
+            trainer_config=trainer_config,
+        )
+        save_nulls_result(nulls_result, out_path / "nulls")
+
+    # 3) Save run config
+    run_config = {
+        "run_id": run_id,
+        "genotype": genotype,
+        "features": features,
+        "learn_res": learn_res,
+        "roi_size": roi_size,
+        "smoothness": smoothness,
+        "null": null,
+        "n_permute": n_permute,
+        "n_boot": n_boot,
+        "n_samples": int(X.shape[0]),
+        "n_channels": int(X.shape[-1]),
+        "random_seed": random_seed,
+    }
+    with open(out_path / "run_config.json", "w") as f:
+        json.dump(run_config, f, indent=2)
+
+    logger.info(f"Run complete: {out_path}")
+    return {
+        "run_id": run_id,
+        "out_dir": str(out_path),
+        "sweep_result": sweep_result,
+        "nulls_result": nulls_result,
+        "config": run_config,
+    }
+
+
+def plot(
+    run_dir: str,
+    style: str = "filled_contours",
+    overlays: Optional[List[str]] = None,
+    save: bool = True,
+) -> None:
+    """
+    Plot ROI discovery results.
+
+    Parameters
+    ----------
+    run_dir : str
+        Path to a completed ROI run directory.
+    style : str
+        "filled_contours" (default) or "heatmap".
+    overlays : list of str, optional
+        ["outline", "optional_S_isolines"]
+    save : bool
+        If True, save plots to run_dir/plots/.
+
+    Note
+    ----
+    This is a placeholder for the plotting infrastructure.
+    The actual plotting will integrate with the existing visualization
+    tools in src/analyze/viz/ and
+    src/analyze/optimal_transport_morphometrics/uot_masks/viz.py.
+
+    For Phase 1, we generate:
+    1. Weight map heatmap (w_full magnitude)
+    2. ROI overlay on reference mask
+    3. Sweep Pareto front plot
+    4. Null distribution histogram
+    5. Bootstrap IoU distribution
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    run_path = Path(run_dir)
+    plot_dir = run_path / "plots"
+    plot_dir.mkdir(exist_ok=True)
+
+    overlays = overlays or ["outline"]
+
+    # Load sweep results
+    sweep_path = run_path / "sweep"
+    if (sweep_path / "sweep_table.csv").exists():
+        sweep_df = pd.read_csv(sweep_path / "sweep_table.csv")
+
+        # Plot 1: Sweep Pareto front
+        fig, ax = plt.subplots(1, 1, figsize=(8, 6))
+        scatter = ax.scatter(
+            sweep_df["area_fraction_mean"],
+            sweep_df["auroc_mean"],
+            c=np.log10(sweep_df["lam"]),
+            cmap="viridis",
+            s=80,
+            edgecolors="k",
+            linewidths=0.5,
+        )
+        plt.colorbar(scatter, ax=ax, label="log10(λ)")
+        ax.set_xlabel("Area Fraction (complexity)")
+        ax.set_ylabel("AUROC")
+        ax.set_title("λ/μ Sweep: AUROC vs ROI Complexity")
+
+        # Mark selected point
+        if (sweep_path / "selection.json").exists():
+            with open(sweep_path / "selection.json") as f:
+                sel = json.load(f)
+            sel_row = sweep_df[
+                (np.isclose(sweep_df["lam"], sel["selected_lam"]))
+                & (np.isclose(sweep_df["mu"], sel["selected_mu"]))
+            ]
+            if len(sel_row) > 0:
+                ax.scatter(
+                    sel_row["area_fraction_mean"],
+                    sel_row["auroc_mean"],
+                    marker="*", s=300, c="red", zorder=5,
+                    label=f"Selected (λ={sel['selected_lam']:.2e})",
+                )
+                ax.legend()
+
+        if save:
+            fig.savefig(plot_dir / "sweep_pareto.png", dpi=150, bbox_inches="tight")
+            plt.close(fig)
+
+    # Plot 2: Null distribution
+    nulls_path = run_path / "nulls"
+    if (nulls_path / "null_aurocs.npy").exists():
+        null_aurocs = np.load(nulls_path / "null_aurocs.npy")
+
+        with open(nulls_path / "nulls_summary.json") as f:
+            nulls_summary = json.load(f)
+
+        fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+        ax.hist(null_aurocs[np.isfinite(null_aurocs)], bins=30, alpha=0.7,
+                color="steelblue", edgecolor="k", label="Null distribution")
+
+        if "permutation" in nulls_summary:
+            obs = nulls_summary["permutation"]["observed_auroc"]
+            pval = nulls_summary["permutation"]["pvalue"]
+            ax.axvline(obs, color="red", linewidth=2, linestyle="--",
+                       label=f"Observed AUROC={obs:.4f}\np={pval:.4f}")
+
+        ax.set_xlabel("AUROC (selection-aware null)")
+        ax.set_ylabel("Count")
+        ax.set_title("NULL 1: Label Permutation Test")
+        ax.legend()
+
+        if save:
+            fig.savefig(plot_dir / "null_permutation.png", dpi=150, bbox_inches="tight")
+            plt.close(fig)
+
+    # Plot 3: Bootstrap IoU
+    if (nulls_path / "bootstrap_ious.npy").exists():
+        ious = np.load(nulls_path / "bootstrap_ious.npy")
+
+        fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+        ax.hist(ious, bins=30, alpha=0.7, color="darkorange", edgecolor="k")
+        ax.axvline(np.mean(ious), color="red", linewidth=2,
+                   label=f"Mean IoU={np.mean(ious):.4f}±{np.std(ious):.4f}")
+        ax.set_xlabel("IoU with Reference ROI")
+        ax.set_ylabel("Count")
+        ax.set_title("NULL 3: Bootstrap ROI Stability")
+        ax.legend()
+
+        if save:
+            fig.savefig(plot_dir / "bootstrap_iou.png", dpi=150, bbox_inches="tight")
+            plt.close(fig)
+
+    logger.info(f"Plots saved to {plot_dir}")
+
+
+def report(run_dir: str) -> Dict:
+    """
+    Generate a summary report for a completed ROI run.
+
+    Returns a dict with:
+        auroc, selected_lam, selected_mu,
+        area_fraction, n_components, boundary_fraction,
+        permutation_pvalue, bootstrap_iou_mean, bootstrap_iou_std
+
+    Also prints a human-readable summary.
+    """
+    run_path = Path(run_dir)
+    result = {}
+
+    # Load sweep selection
+    sel_path = run_path / "sweep" / "selection.json"
+    if sel_path.exists():
+        with open(sel_path) as f:
+            sel = json.load(f)
+        result["auroc"] = sel["selected_auroc"]
+        result["selected_lam"] = sel["selected_lam"]
+        result["selected_mu"] = sel["selected_mu"]
+        result.update(sel.get("selected_complexity", {}))
+        result["selection_rule"] = sel["selection_rule"]
+
+    # Load nulls
+    nulls_path = run_path / "nulls" / "nulls_summary.json"
+    if nulls_path.exists():
+        with open(nulls_path) as f:
+            nulls = json.load(f)
+        if "permutation" in nulls:
+            result["permutation_pvalue"] = nulls["permutation"]["pvalue"]
+            result["null_auroc_mean"] = nulls["permutation"]["null_mean"]
+        if "bootstrap" in nulls:
+            result["bootstrap_iou_mean"] = nulls["bootstrap"]["iou_mean"]
+            result["bootstrap_iou_std"] = nulls["bootstrap"]["iou_std"]
+
+    # Print summary
+    print("=" * 60)
+    print("ROI Discovery Report")
+    print("=" * 60)
+    if "auroc" in result:
+        print(f"  AUROC:              {result['auroc']:.4f}")
+    if "selected_lam" in result:
+        print(f"  Selected λ:         {result['selected_lam']:.2e}")
+    if "selected_mu" in result:
+        print(f"  Selected μ:         {result['selected_mu']:.2e}")
+    if "area_fraction" in result:
+        print(f"  ROI Area Fraction:  {result['area_fraction']:.4f}")
+    if "n_components" in result:
+        print(f"  ROI Components:     {result['n_components']:.1f}")
+    if "boundary_fraction" in result:
+        print(f"  Boundary Fraction:  {result['boundary_fraction']:.4f}")
+    if "permutation_pvalue" in result:
+        print(f"  Permutation p:      {result['permutation_pvalue']:.4f}")
+    if "bootstrap_iou_mean" in result:
+        print(
+            f"  Bootstrap IoU:      "
+            f"{result['bootstrap_iou_mean']:.4f}"
+            f"±{result['bootstrap_iou_std']:.4f}"
+        )
+    print("=" * 60)
+
+    return result
+
+
+__all__ = ["fit", "plot", "report"]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_api.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_api.py
@@ -26,7 +26,6 @@ from roi_config import (
     FeatureSet,
     NullConfig,
     NullMode,
-    ROIRunConfig,
     ROISizePreset,
     SmoothnessPreset,
     SweepConfig,

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_config.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_config.py
@@ -141,33 +141,29 @@ class NullConfig:
     random_seed: int = 42
 
 
-# NOTE: ROIRunConfig is commented out for now — the API (roi_api.fit)
-# takes flat kwargs instead. Uncomment and wire in if a single config
-# object becomes useful once the pipeline matures.
-#
-# @dataclass
-# class ROIRunConfig:
-#     """Top-level run configuration combining all sub-configs."""
-#     genotype: str = "cep290"
-#     reference: str = "WT"
-#     features: FeatureSet = FeatureSet.COST
-#     roi_size: ROISizePreset = ROISizePreset.MEDIUM
-#     smoothness: SmoothnessPreset = SmoothnessPreset.MEDIUM
-#
-#     dataset: FeatureDatasetConfig = field(default_factory=FeatureDatasetConfig)
-#     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-#     sweep: SweepConfig = field(default_factory=SweepConfig)
-#     nulls: NullConfig = field(default_factory=NullConfig)
-#
-#     out_dir: Optional[str] = None
-#
-#     def resolve_lambda_values(self) -> List[float]:
-#         """Get λ values from preset or sweep config."""
-#         return list(LAMBDA_PRESETS.get(self.roi_size, self.sweep.lambda_values))
-#
-#     def resolve_mu_values(self) -> List[float]:
-#         """Get μ values from preset or sweep config."""
-#         return list(MU_PRESETS.get(self.smoothness, self.sweep.mu_values))
+@dataclass
+class ROIRunConfig:
+    """Top-level run configuration combining all sub-configs."""
+    genotype: str = "cep290"
+    reference: str = "WT"
+    features: FeatureSet = FeatureSet.COST
+    roi_size: ROISizePreset = ROISizePreset.MEDIUM
+    smoothness: SmoothnessPreset = SmoothnessPreset.MEDIUM
+
+    dataset: FeatureDatasetConfig = field(default_factory=FeatureDatasetConfig)
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)
+    sweep: SweepConfig = field(default_factory=SweepConfig)
+    nulls: NullConfig = field(default_factory=NullConfig)
+
+    out_dir: Optional[str] = None
+
+    def resolve_lambda_values(self) -> List[float]:
+        """Get λ values from preset or sweep config."""
+        return list(LAMBDA_PRESETS.get(self.roi_size, self.sweep.lambda_values))
+
+    def resolve_mu_values(self) -> List[float]:
+        """Get μ values from preset or sweep config."""
+        return list(MU_PRESETS.get(self.smoothness, self.sweep.mu_values))
 
 
 __all__ = [
@@ -182,7 +178,7 @@ __all__ = [
     "TrainerConfig",
     "SweepConfig",
     "NullConfig",
-    # "ROIRunConfig",  # commented out — see note above
+    "ROIRunConfig",
     "LAMBDA_PRESETS",
     "MU_PRESETS",
 ]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_config.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_config.py
@@ -141,29 +141,33 @@ class NullConfig:
     random_seed: int = 42
 
 
-@dataclass
-class ROIRunConfig:
-    """Top-level run configuration combining all sub-configs."""
-    genotype: str = "cep290"
-    reference: str = "WT"
-    features: FeatureSet = FeatureSet.COST
-    roi_size: ROISizePreset = ROISizePreset.MEDIUM
-    smoothness: SmoothnessPreset = SmoothnessPreset.MEDIUM
-
-    dataset: FeatureDatasetConfig = field(default_factory=FeatureDatasetConfig)
-    trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    sweep: SweepConfig = field(default_factory=SweepConfig)
-    nulls: NullConfig = field(default_factory=NullConfig)
-
-    out_dir: Optional[str] = None
-
-    def resolve_lambda_values(self) -> List[float]:
-        """Get λ values from preset or sweep config."""
-        return list(LAMBDA_PRESETS.get(self.roi_size, self.sweep.lambda_values))
-
-    def resolve_mu_values(self) -> List[float]:
-        """Get μ values from preset or sweep config."""
-        return list(MU_PRESETS.get(self.smoothness, self.sweep.mu_values))
+# NOTE: ROIRunConfig is commented out for now — the API (roi_api.fit)
+# takes flat kwargs instead. Uncomment and wire in if a single config
+# object becomes useful once the pipeline matures.
+#
+# @dataclass
+# class ROIRunConfig:
+#     """Top-level run configuration combining all sub-configs."""
+#     genotype: str = "cep290"
+#     reference: str = "WT"
+#     features: FeatureSet = FeatureSet.COST
+#     roi_size: ROISizePreset = ROISizePreset.MEDIUM
+#     smoothness: SmoothnessPreset = SmoothnessPreset.MEDIUM
+#
+#     dataset: FeatureDatasetConfig = field(default_factory=FeatureDatasetConfig)
+#     trainer: TrainerConfig = field(default_factory=TrainerConfig)
+#     sweep: SweepConfig = field(default_factory=SweepConfig)
+#     nulls: NullConfig = field(default_factory=NullConfig)
+#
+#     out_dir: Optional[str] = None
+#
+#     def resolve_lambda_values(self) -> List[float]:
+#         """Get λ values from preset or sweep config."""
+#         return list(LAMBDA_PRESETS.get(self.roi_size, self.sweep.lambda_values))
+#
+#     def resolve_mu_values(self) -> List[float]:
+#         """Get μ values from preset or sweep config."""
+#         return list(MU_PRESETS.get(self.smoothness, self.sweep.mu_values))
 
 
 __all__ = [
@@ -178,7 +182,7 @@ __all__ = [
     "TrainerConfig",
     "SweepConfig",
     "NullConfig",
-    "ROIRunConfig",
+    # "ROIRunConfig",  # commented out — see note above
     "LAMBDA_PRESETS",
     "MU_PRESETS",
 ]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_config.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_config.py
@@ -1,0 +1,184 @@
+"""
+Configuration dataclasses for ROI discovery via OT feature maps.
+
+Follows the same frozen-dataclass pattern as UOTConfig in
+src/analyze/utils/optimal_transport/config.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+class FeatureSet(str, Enum):
+    """Which OT-derived channels to use as input features."""
+    COST = "cost"
+    COST_DISP = "cost+disp"
+    ALL_OT = "all_ot"
+
+
+class ROISizePreset(str, Enum):
+    """Maps to λ (L1 penalty) grid presets."""
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+
+
+class SmoothnessPreset(str, Enum):
+    """Maps to μ (TV penalty) grid presets."""
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class NullMode(str, Enum):
+    PERMUTE = "permute"
+    BOOTSTRAP = "bootstrap"
+    BOTH = "both"
+    NONE = "none"
+
+
+class SelectionRule(str, Enum):
+    """Deterministic selection rule for (λ,μ) from sweep."""
+    PARETO_KNEE = "pareto_knee"       # Option A: knee on Pareto front
+    EPSILON_BEST = "epsilon_best"     # Option B: smallest complexity within ε of best AUROC
+
+
+# ---------------------------------------------------------------------------
+# λ/μ presets — these are *starting points*, not universal truths.
+# Biology-dependent tuning will refine them.
+# ---------------------------------------------------------------------------
+
+LAMBDA_PRESETS = {
+    ROISizePreset.SMALL:  [1e-2, 3e-2, 1e-1, 3e-1],
+    ROISizePreset.MEDIUM: [1e-3, 3e-3, 1e-2, 3e-2],
+    ROISizePreset.LARGE:  [1e-4, 3e-4, 1e-3, 3e-3],
+}
+
+MU_PRESETS = {
+    SmoothnessPreset.LOW:    [1e-4, 1e-3, 1e-2],
+    SmoothnessPreset.MEDIUM: [1e-3, 1e-2, 1e-1],
+    SmoothnessPreset.HIGH:   [1e-2, 1e-1, 1.0],
+}
+
+
+@dataclass(frozen=True)
+class FeatureDatasetConfig:
+    """Configuration for the on-disk FeatureDataset contract."""
+    canonical_grid_hw: Tuple[int, int] = (512, 512)
+    chunk_size_n: int = 8
+    compression: str = "zstd"
+    compression_level: int = 3
+    iqr_multiplier: float = 1.5       # for QC outlier filter on total_cost_C
+    group_key: str = "embryo_id"      # MANDATORY: prevents leakage in CV splits
+
+
+@dataclass(frozen=True)
+class ChannelSchema:
+    """Describes a single feature channel in the dataset."""
+    name: str
+    definition: str
+    units: str
+
+
+# Standard channel schemas for OT-derived features
+CHANNEL_SCHEMAS = {
+    FeatureSet.COST: [
+        ChannelSchema("total_cost", "Per-pixel OT transport cost", "cost_units"),
+    ],
+    FeatureSet.COST_DISP: [
+        ChannelSchema("total_cost", "Per-pixel OT transport cost", "cost_units"),
+        ChannelSchema("displacement_y", "Barycentric displacement (y)", "um"),
+        ChannelSchema("displacement_x", "Barycentric displacement (x)", "um"),
+    ],
+    FeatureSet.ALL_OT: [
+        ChannelSchema("total_cost", "Per-pixel OT transport cost", "cost_units"),
+        ChannelSchema("displacement_y", "Barycentric displacement (y)", "um"),
+        ChannelSchema("displacement_x", "Barycentric displacement (x)", "um"),
+        ChannelSchema("mass_created", "Mass creation per pixel", "mass_units"),
+        ChannelSchema("mass_destroyed", "Mass destruction per pixel", "mass_units"),
+    ],
+}
+
+
+@dataclass(frozen=True)
+class TrainerConfig:
+    """JAX trainer configuration."""
+    learn_res: int = 128
+    output_res: int = 512
+    learning_rate: float = 1e-2
+    max_steps: int = 2000
+    convergence_tol: float = 1e-6
+    log_every: int = 100
+    random_seed: int = 42
+
+
+@dataclass(frozen=True)
+class SweepConfig:
+    """λ/μ sweep configuration."""
+    lambda_values: Tuple[float, ...] = (1e-3, 3e-3, 1e-2, 3e-2, 1e-1)
+    mu_values: Tuple[float, ...] = (1e-3, 1e-2, 1e-1)
+    n_cv_folds: int = 5
+    selection_rule: SelectionRule = SelectionRule.PARETO_KNEE
+    # For PARETO_KNEE: beta controls knee sensitivity
+    pareto_beta: float = 1.0
+    # For EPSILON_BEST: ε tolerance on AUROC
+    epsilon_auroc: float = 0.02
+    # ROI extraction
+    roi_quantile: float = 0.9    # threshold |w| at this quantile
+
+
+@dataclass(frozen=True)
+class NullConfig:
+    """Null distribution + stability configuration."""
+    null_mode: NullMode = NullMode.BOTH
+    n_permute: int = 100
+    n_boot: int = 200
+    boot_roi_quantile: float = 0.9
+    random_seed: int = 42
+
+
+@dataclass
+class ROIRunConfig:
+    """Top-level run configuration combining all sub-configs."""
+    genotype: str = "cep290"
+    reference: str = "WT"
+    features: FeatureSet = FeatureSet.COST
+    roi_size: ROISizePreset = ROISizePreset.MEDIUM
+    smoothness: SmoothnessPreset = SmoothnessPreset.MEDIUM
+
+    dataset: FeatureDatasetConfig = field(default_factory=FeatureDatasetConfig)
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)
+    sweep: SweepConfig = field(default_factory=SweepConfig)
+    nulls: NullConfig = field(default_factory=NullConfig)
+
+    out_dir: Optional[str] = None
+
+    def resolve_lambda_values(self) -> List[float]:
+        """Get λ values from preset or sweep config."""
+        return list(LAMBDA_PRESETS.get(self.roi_size, self.sweep.lambda_values))
+
+    def resolve_mu_values(self) -> List[float]:
+        """Get μ values from preset or sweep config."""
+        return list(MU_PRESETS.get(self.smoothness, self.sweep.mu_values))
+
+
+__all__ = [
+    "FeatureSet",
+    "ROISizePreset",
+    "SmoothnessPreset",
+    "NullMode",
+    "SelectionRule",
+    "FeatureDatasetConfig",
+    "ChannelSchema",
+    "CHANNEL_SCHEMAS",
+    "TrainerConfig",
+    "SweepConfig",
+    "NullConfig",
+    "ROIRunConfig",
+    "LAMBDA_PRESETS",
+    "MU_PRESETS",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_feature_dataset.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_feature_dataset.py
@@ -1,0 +1,382 @@
+"""
+FeatureDataset builder + validator for ROI discovery.
+
+Contract-first: Zarr (arrays) + Parquet (metadata) + JSON manifest.
+Follows the Parquet storage patterns from
+src/analyze/optimal_transport_morphometrics/uot_masks/feature_compaction/storage.py.
+
+Usage:
+    # Build from OT results
+    builder = FeatureDatasetBuilder(
+        ot_results_dir="path/to/ot_outputs",
+        out_dir="roi_feature_dataset_cep290",
+        feature_set=FeatureSet.COST,
+    )
+    builder.build()
+
+    # Validate an existing dataset
+    validate_feature_dataset("roi_feature_dataset_cep290")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:
+    import zarr
+except ImportError:
+    zarr = None
+
+from roi_config import (
+    CHANNEL_SCHEMAS,
+    ChannelSchema,
+    FeatureDatasetConfig,
+    FeatureSet,
+)
+
+logger = logging.getLogger(__name__)
+
+# Schema version for forward-compatibility checks
+SCHEMA_VERSION = "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+def _build_manifest(
+    config: FeatureDatasetConfig,
+    feature_set: FeatureSet,
+    channel_schemas: List[ChannelSchema],
+    n_samples: int,
+    n_channels: int,
+    class_counts: Dict[int, int],
+    provenance: Optional[Dict] = None,
+) -> Dict:
+    """Build the manifest.json dict (hard validation fields included)."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "canonical_grid": list(config.canonical_grid_hw),
+        "feature_set": feature_set.value,
+        "channel_schema": [
+            {"name": cs.name, "definition": cs.definition, "units": cs.units}
+            for cs in channel_schemas
+        ],
+        "n_samples": n_samples,
+        "n_channels": n_channels,
+        "class_counts": class_counts,
+        "qc_rules": {
+            "iqr_multiplier": config.iqr_multiplier,
+            "outlier_field": "qc/outlier_flag",
+            "cost_field": "qc/total_cost_C",
+            "policy": "log_and_flag_never_delete",
+        },
+        "split_policy": {
+            "group_key": config.group_key,
+            "strategy": "GroupKFold_by_embryo_id",
+            "note": "MANDATORY: prevents leakage across folds",
+        },
+        "class_balance_strategy": {
+            "method": "sklearn_balanced_class_weight",
+            "scope": "train_fold_only",
+            "note": "Matches existing MorphSeq classification code (class_weight='balanced')",
+        },
+        "chunking": {
+            "X": [config.chunk_size_n, *config.canonical_grid_hw, n_channels],
+            "compression": config.compression,
+            "compression_level": config.compression_level,
+        },
+        "provenance": provenance or {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+class DatasetValidationError(Exception):
+    """Raised when a FeatureDataset fails schema validation."""
+    pass
+
+
+def validate_feature_dataset(dataset_dir: str | Path) -> Dict:
+    """
+    Validate a FeatureDataset directory against the contract.
+
+    Performs fail-fast schema checks with informative errors.
+
+    Returns the parsed manifest on success.
+    Raises DatasetValidationError with details on failure.
+    """
+    root = Path(dataset_dir)
+    errors = []
+
+    # 1) Check directory exists
+    if not root.is_dir():
+        raise DatasetValidationError(f"Dataset directory does not exist: {root}")
+
+    # 2) manifest.json
+    manifest_path = root / "manifest.json"
+    if not manifest_path.exists():
+        raise DatasetValidationError(f"Missing manifest.json in {root}")
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    required_keys = [
+        "schema_version", "canonical_grid", "feature_set", "channel_schema",
+        "n_samples", "n_channels", "qc_rules", "split_policy",
+        "class_balance_strategy", "chunking",
+    ]
+    for key in required_keys:
+        if key not in manifest:
+            errors.append(f"manifest.json missing required key: '{key}'")
+
+    if errors:
+        raise DatasetValidationError(
+            f"Manifest validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    # 3) metadata.parquet
+    meta_path = root / "metadata.parquet"
+    if not meta_path.exists():
+        errors.append("Missing metadata.parquet")
+    else:
+        df_meta = pd.read_parquet(meta_path)
+        group_key = manifest["split_policy"]["group_key"]
+        if group_key not in df_meta.columns:
+            errors.append(
+                f"metadata.parquet missing required group_key column: '{group_key}'"
+            )
+        required_meta_cols = [group_key, "genotype", "sample_index"]
+        for col in required_meta_cols:
+            if col not in df_meta.columns:
+                errors.append(f"metadata.parquet missing column: '{col}'")
+
+    # 4) features.zarr
+    zarr_path = root / "features.zarr"
+    if not zarr_path.exists():
+        errors.append("Missing features.zarr directory")
+    elif zarr is not None:
+        try:
+            store = zarr.open(str(zarr_path), mode="r")
+        except Exception as e:
+            errors.append(f"Cannot open features.zarr: {e}")
+        else:
+            expected_arrays = ["X", "y", "mask_ref"]
+            for name in expected_arrays:
+                if name not in store:
+                    errors.append(f"features.zarr missing array: '{name}'")
+
+            if "X" in store:
+                X = store["X"]
+                n_samples = manifest["n_samples"]
+                n_channels = manifest["n_channels"]
+                grid = tuple(manifest["canonical_grid"])
+                expected_shape = (n_samples, *grid, n_channels)
+                if X.shape != expected_shape:
+                    errors.append(
+                        f"X shape mismatch: got {X.shape}, expected {expected_shape}"
+                    )
+                if X.dtype != np.float32:
+                    errors.append(f"X dtype should be float32, got {X.dtype}")
+
+            if "y" in store:
+                y = store["y"]
+                if y.shape != (manifest["n_samples"],):
+                    errors.append(
+                        f"y shape mismatch: got {y.shape}, expected ({manifest['n_samples']},)"
+                    )
+
+            if "mask_ref" in store:
+                mask = store["mask_ref"]
+                grid = tuple(manifest["canonical_grid"])
+                if mask.shape != grid:
+                    errors.append(
+                        f"mask_ref shape mismatch: got {mask.shape}, expected {grid}"
+                    )
+
+            # QC arrays
+            if "qc" not in store:
+                errors.append("features.zarr missing 'qc' group")
+            else:
+                qc = store["qc"]
+                for qc_name in ["total_cost_C", "outlier_flag"]:
+                    if qc_name not in qc:
+                        errors.append(f"features.zarr/qc missing: '{qc_name}'")
+
+    if errors:
+        raise DatasetValidationError(
+            f"Dataset validation failed ({len(errors)} errors):\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    logger.info(f"Dataset validated: {root} ({manifest['n_samples']} samples)")
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+class FeatureDatasetBuilder:
+    """
+    Build a FeatureDataset from OT results.
+
+    This builder collects OT-derived feature maps (cost, displacement,
+    mass creation/destruction) already rasterized to the 512x512 canonical
+    grid and packages them into the contract format.
+
+    The actual OT computation is NOT done here — we consume outputs from
+    the existing UOT pipeline (run_transport.py / transport_maps.py).
+    """
+
+    def __init__(
+        self,
+        ot_results_dir: str | Path,
+        out_dir: str | Path,
+        feature_set: FeatureSet = FeatureSet.COST,
+        config: Optional[FeatureDatasetConfig] = None,
+        genotype_col: str = "genotype",
+        reference_genotype: str = "WT",
+        target_genotype: str = "cep290",
+    ):
+        self.ot_results_dir = Path(ot_results_dir)
+        self.out_dir = Path(out_dir)
+        self.feature_set = feature_set
+        self.config = config or FeatureDatasetConfig()
+        self.genotype_col = genotype_col
+        self.reference_genotype = reference_genotype
+        self.target_genotype = target_genotype
+        self.channel_schemas = CHANNEL_SCHEMAS[feature_set]
+
+    def build(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        mask_ref: np.ndarray,
+        metadata_df: pd.DataFrame,
+        total_cost_C: np.ndarray,
+        provenance: Optional[Dict] = None,
+    ) -> Path:
+        """
+        Build and write the FeatureDataset to disk.
+
+        Parameters
+        ----------
+        X : ndarray, shape (N, 512, 512, C)
+            Feature maps on the canonical grid.
+        y : ndarray, shape (N,)
+            Binary labels (0 = reference, 1 = target genotype).
+        mask_ref : ndarray, shape (512, 512)
+            Reference embryo mask on canonical grid.
+        metadata_df : DataFrame
+            Per-sample metadata. Must contain 'embryo_id' and 'genotype'.
+        total_cost_C : ndarray, shape (N,)
+            Total OT cost per sample (for QC filtering).
+        provenance : dict, optional
+            Provenance info (source paths, git hash, etc).
+
+        Returns
+        -------
+        Path to the created dataset directory.
+        """
+        if zarr is None:
+            raise ImportError("zarr is required to build FeatureDataset. pip install zarr")
+
+        N, H, W, C = X.shape
+        grid = self.config.canonical_grid_hw
+
+        # Validate shapes
+        assert (H, W) == grid, f"X spatial dims {(H, W)} != canonical_grid {grid}"
+        assert y.shape == (N,), f"y shape {y.shape} != ({N},)"
+        assert mask_ref.shape == grid, f"mask_ref shape {mask_ref.shape} != {grid}"
+        assert total_cost_C.shape == (N,), f"total_cost_C shape != ({N},)"
+        assert len(metadata_df) == N, f"metadata length {len(metadata_df)} != {N}"
+        assert C == len(self.channel_schemas), (
+            f"X has {C} channels but channel_schema has {len(self.channel_schemas)}"
+        )
+
+        # QC: IQR outlier detection on total_cost_C
+        q1 = np.percentile(total_cost_C, 25)
+        q3 = np.percentile(total_cost_C, 75)
+        iqr = q3 - q1
+        lower = q1 - self.config.iqr_multiplier * iqr
+        upper = q3 + self.config.iqr_multiplier * iqr
+        outlier_flag = (total_cost_C < lower) | (total_cost_C > upper)
+        n_outliers = int(outlier_flag.sum())
+        logger.info(
+            f"QC: {n_outliers}/{N} samples flagged as outliers "
+            f"(IQR={iqr:.4f}, bounds=[{lower:.4f}, {upper:.4f}])"
+        )
+
+        # Create output directory
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write Zarr
+        zarr_path = self.out_dir / "features.zarr"
+        store = zarr.open(str(zarr_path), mode="w")
+
+        chunk_n = self.config.chunk_size_n
+        compressor = zarr.storage.default_compressor
+
+        store.create_dataset(
+            "X", data=X.astype(np.float32),
+            chunks=(chunk_n, H, W, C),
+            dtype=np.float32,
+        )
+        store.create_dataset("y", data=y.astype(np.int32), dtype=np.int32)
+        store.create_dataset(
+            "mask_ref", data=mask_ref.astype(np.uint8), dtype=np.uint8,
+        )
+
+        qc_group = store.create_group("qc")
+        qc_group.create_dataset(
+            "total_cost_C", data=total_cost_C.astype(np.float32), dtype=np.float32,
+        )
+        qc_group.create_dataset(
+            "outlier_flag", data=outlier_flag, dtype=bool,
+        )
+
+        # Write metadata Parquet
+        metadata_df = metadata_df.copy()
+        metadata_df["sample_index"] = np.arange(N)
+        metadata_df.to_parquet(self.out_dir / "metadata.parquet", index=False)
+
+        # Class counts
+        unique, counts = np.unique(y, return_counts=True)
+        class_counts = {int(u): int(c) for u, c in zip(unique, counts)}
+
+        # Write manifest
+        manifest = _build_manifest(
+            config=self.config,
+            feature_set=self.feature_set,
+            channel_schemas=self.channel_schemas,
+            n_samples=N,
+            n_channels=C,
+            class_counts=class_counts,
+            provenance=provenance,
+        )
+        with open(self.out_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f, indent=2)
+
+        # Validate what we just wrote
+        validate_feature_dataset(self.out_dir)
+
+        logger.info(f"FeatureDataset built: {self.out_dir} ({N} samples, {C} channels)")
+        return self.out_dir
+
+
+__all__ = [
+    "FeatureDatasetBuilder",
+    "validate_feature_dataset",
+    "DatasetValidationError",
+    "SCHEMA_VERSION",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_loader.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_loader.py
@@ -1,0 +1,176 @@
+"""
+Streaming loader for ROI FeatureDatasets.
+
+Supports:
+- Full-batch (small N) and minibatch (large N) loading
+- Deterministic filtering via qc/outlier_flag
+- Embryo-grouped CV splits (prevents leakage)
+- Fold-local class weights (computed from training fold only)
+
+Follows the same grouped-CV pattern used in
+src/analyze/difference_detection/classification_test.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import GroupKFold
+from sklearn.utils.class_weight import compute_class_weight
+
+try:
+    import zarr
+except ImportError:
+    zarr = None
+
+logger = logging.getLogger(__name__)
+
+
+class FeatureLoader:
+    """
+    Loader for a validated FeatureDataset.
+
+    Handles QC filtering, CV split generation, and class weighting.
+    """
+
+    def __init__(
+        self,
+        dataset_dir: str | Path,
+        exclude_outliers: bool = True,
+    ):
+        self.root = Path(dataset_dir)
+
+        if zarr is None:
+            raise ImportError("zarr required for FeatureLoader")
+
+        import json
+        with open(self.root / "manifest.json") as f:
+            self.manifest = json.load(f)
+
+        self.metadata = pd.read_parquet(self.root / "metadata.parquet")
+        self.store = zarr.open(str(self.root / "features.zarr"), mode="r")
+
+        self.N = self.manifest["n_samples"]
+        self.grid_hw = tuple(self.manifest["canonical_grid"])
+        self.n_channels = self.manifest["n_channels"]
+        self.group_key = self.manifest["split_policy"]["group_key"]
+
+        # Deterministic filtering
+        outlier_flag = np.array(self.store["qc"]["outlier_flag"])
+        if exclude_outliers:
+            self._valid_mask = ~outlier_flag
+            n_excluded = int(outlier_flag.sum())
+            if n_excluded > 0:
+                logger.info(
+                    f"Excluding {n_excluded}/{self.N} outlier samples "
+                    f"(QC IQR filter)"
+                )
+        else:
+            self._valid_mask = np.ones(self.N, dtype=bool)
+
+        self._valid_indices = np.where(self._valid_mask)[0]
+
+    @property
+    def n_valid(self) -> int:
+        return len(self._valid_indices)
+
+    def load_full(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Load all valid samples into memory.
+
+        Returns (X, y, groups) where groups are embryo_id values
+        for use in GroupKFold.
+        """
+        idx = self._valid_indices
+        X = np.array(self.store["X"])[idx]  # (N_valid, H, W, C)
+        y = np.array(self.store["y"])[idx]  # (N_valid,)
+        groups = self.metadata.iloc[idx][self.group_key].values
+        return X, y, groups
+
+    def load_mask_ref(self) -> np.ndarray:
+        """Load the reference mask (512x512)."""
+        return np.array(self.store["mask_ref"])
+
+    def iter_batches(
+        self,
+        batch_size: int = 16,
+        shuffle: bool = False,
+        random_seed: int = 42,
+    ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
+        """
+        Iterate over valid samples in batches.
+
+        Yields (X_batch, y_batch) tuples.
+        """
+        idx = self._valid_indices.copy()
+        if shuffle:
+            rng = np.random.default_rng(random_seed)
+            rng.shuffle(idx)
+
+        for start in range(0, len(idx), batch_size):
+            batch_idx = idx[start : start + batch_size]
+            X_batch = np.array(self.store["X"][batch_idx])
+            y_batch = np.array(self.store["y"][batch_idx])
+            yield X_batch, y_batch
+
+    def generate_cv_splits(
+        self,
+        n_folds: int = 5,
+    ) -> List[Dict]:
+        """
+        Generate GroupKFold CV splits grouped by embryo_id.
+
+        Returns a list of dicts with keys:
+            fold, train_idx, val_idx, train_groups, val_groups,
+            class_weights_train
+
+        Class weights are computed from the TRAINING fold only,
+        matching the MorphSeq class_weight='balanced' convention.
+        """
+        X_all, y_all, groups_all = self.load_full()
+
+        # GroupKFold ensures no embryo appears in both train and val
+        gkf = GroupKFold(n_splits=n_folds)
+        splits = []
+
+        for fold_i, (train_idx, val_idx) in enumerate(
+            gkf.split(X_all, y_all, groups_all)
+        ):
+            y_train = y_all[train_idx]
+
+            # Compute class weights from TRAINING fold only
+            classes = np.unique(y_train)
+            weights = compute_class_weight(
+                class_weight="balanced",
+                classes=classes,
+                y=y_train,
+            )
+            class_weight_dict = {int(c): float(w) for c, w in zip(classes, weights)}
+
+            splits.append({
+                "fold": fold_i,
+                "train_idx": train_idx,
+                "val_idx": val_idx,
+                "train_groups": groups_all[train_idx],
+                "val_groups": groups_all[val_idx],
+                "class_weights_train": class_weight_dict,
+                "n_train": len(train_idx),
+                "n_val": len(val_idx),
+                "train_class_counts": {
+                    int(c): int(np.sum(y_train == c)) for c in classes
+                },
+            })
+
+            logger.info(
+                f"Fold {fold_i}: train={len(train_idx)}, val={len(val_idx)}, "
+                f"class_weights={class_weight_dict}"
+            )
+
+        return splits
+
+
+__all__ = ["FeatureLoader"]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_loader.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_loader.py
@@ -95,6 +95,13 @@ class FeatureLoader:
         """Load the reference mask (512x512)."""
         return np.array(self.store["mask_ref"])
 
+    def get_channel_names(self) -> Tuple[str, ...]:
+        """Return channel names from the manifest channel_schema in order."""
+        schema = self.manifest.get("channel_schema", [])
+        if not schema:
+            return tuple(f"channel_{i}" for i in range(self.n_channels))
+        return tuple(str(channel["name"]) for channel in schema)
+
     def iter_batches(
         self,
         batch_size: int = 16,

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_mask_objective.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_mask_objective.py
@@ -1,0 +1,29 @@
+"""Differentiable perturbation objectives for Phase 2.5a."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+
+def apply_perturbation(X: jnp.ndarray, mask_full: jnp.ndarray, baseline: jnp.ndarray) -> jnp.ndarray:
+    m = mask_full[None, :, :, None]
+    return m * X + (1.0 - m) * baseline[None, :, :, :]
+
+
+def compute_score(logits: jnp.ndarray) -> jnp.ndarray:
+    return logits.mean()
+
+
+def dual_objective(
+    X: jnp.ndarray,
+    mask_full: jnp.ndarray,
+    baseline: jnp.ndarray,
+    w_full: jnp.ndarray,
+    b: float,
+) -> jnp.ndarray:
+    preserve = apply_perturbation(X, mask_full, baseline)
+    delete = apply_perturbation(X, 1.0 - mask_full, baseline)
+
+    z_preserve = jnp.sum(preserve * w_full[None, :, :, :], axis=(1, 2, 3)) + b
+    z_delete = jnp.sum(delete * w_full[None, :, :, :], axis=(1, 2, 3)) + b
+    return compute_score(z_preserve) - compute_score(z_delete)

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_mask_param.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_mask_param.py
@@ -1,0 +1,31 @@
+"""Mask parameterization utilities for Phase 2.5a fixed-model mask learning."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import jax
+import jax.numpy as jnp
+from jax.image import resize as jax_resize
+
+
+def mask_from_param(mask_param: jnp.ndarray, temperature: float = 1.0) -> jnp.ndarray:
+    """Convert unconstrained mask parameters to soft mask in (0,1)."""
+    return jax.nn.sigmoid(mask_param / jnp.float32(temperature))
+
+
+def upsample_mask(mask_low: jnp.ndarray, output_hw: Tuple[int, int]) -> jnp.ndarray:
+    """Bilinear upsample low-res mask to full resolution."""
+    return jax_resize(mask_low[:, :, None], (*output_hw, 1), method="bilinear")[:, :, 0]
+
+
+def tv_loss(mask_low: jnp.ndarray) -> jnp.ndarray:
+    """Anisotropic TV penalty on a 2D soft mask."""
+    dy = jnp.abs(mask_low[1:, :] - mask_low[:-1, :]).sum()
+    dx = jnp.abs(mask_low[:, 1:] - mask_low[:, :-1]).sum()
+    return dx + dy
+
+
+def jitter_mask(mask_full: jnp.ndarray, shift_y: int, shift_x: int) -> jnp.ndarray:
+    """Circularly shift mask as a simple anti-cheating jitter mechanism."""
+    return jnp.roll(jnp.roll(mask_full, shift_y, axis=0), shift_x, axis=1)

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_mask_trainer.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_mask_trainer.py
@@ -1,0 +1,87 @@
+"""Phase 2.5a trainer: learn a global soft ROI mask with a fixed classifier."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+from roi_mask_objective import dual_objective
+from roi_mask_param import jitter_mask, mask_from_param, tv_loss, upsample_mask
+
+
+@dataclass
+class MaskTrainResult:
+    mask_low: np.ndarray
+    mask_full: np.ndarray
+    objective_log: List[Dict[str, float]]
+
+
+def train_mask_fixed_model(
+    X: np.ndarray,
+    w_full: np.ndarray,
+    b: float,
+    baseline: np.ndarray,
+    mask_ref: np.ndarray,
+    learn_res: int = 128,
+    n_steps: int = 500,
+    learning_rate: float = 1e-2,
+    l1_weight: float = 1e-3,
+    tv_weight: float = 1e-3,
+    entropy_weight: float = 0.0,
+    temperature: float = 1.0,
+    jitter_px: int = 2,
+    random_seed: int = 42,
+) -> MaskTrainResult:
+    """Optimize a global mask m for a fixed (w,b) classifier using the dual objective."""
+    X_j = jnp.array(X, dtype=jnp.float32)
+    w_j = jnp.array(w_full, dtype=jnp.float32)
+    baseline_j = jnp.array(baseline, dtype=jnp.float32)
+
+    mask_ref_low = jax.image.resize(
+        jnp.array(mask_ref, dtype=jnp.float32)[:, :, None],
+        (learn_res, learn_res, 1),
+        method="nearest",
+    )[:, :, 0]
+
+    params = {"mask_param": jnp.zeros((learn_res, learn_res), dtype=jnp.float32)}
+    opt = optax.adam(learning_rate)
+    state = opt.init(params)
+    rng = jax.random.PRNGKey(random_seed)
+
+    @jax.jit
+    def step(params, state, rng):
+        rng, shift_rng = jax.random.split(rng)
+        shift = jax.random.randint(shift_rng, (2,), minval=-jitter_px, maxval=jitter_px + 1)
+
+        def loss_fn(p):
+            m_low = mask_from_param(p["mask_param"], temperature=temperature) * mask_ref_low
+            m_full = upsample_mask(m_low, w_j.shape[:2]) * jnp.array(mask_ref, dtype=jnp.float32)
+            m_full = jitter_mask(m_full, shift[0], shift[1])
+
+            dual = dual_objective(X_j, m_full, baseline_j, w_j, b)
+            l1 = jnp.mean(jnp.abs(m_low))
+            tv = tv_loss(m_low) / jnp.float32(m_low.size)
+            entropy = jnp.mean(m_low * (1.0 - m_low))
+            total = -(dual - l1_weight * l1 - tv_weight * tv - entropy_weight * entropy)
+            return total, {"dual": dual, "l1": l1, "tv": tv, "entropy": entropy}
+
+        (loss, aux), grads = jax.value_and_grad(loss_fn, has_aux=True)(params)
+        updates, state = opt.update(grads, state, params)
+        params = optax.apply_updates(params, updates)
+        return params, state, rng, loss, aux
+
+    logs: List[Dict[str, float]] = []
+    for step_i in range(n_steps):
+        params, state, rng, loss, aux = step(params, state, rng)
+        if step_i % 25 == 0 or step_i == n_steps - 1:
+            logs.append({"step": float(step_i), "loss": float(loss), **{k: float(v) for k, v in aux.items()}})
+
+    mask_low = np.array(mask_from_param(params["mask_param"], temperature=temperature) * mask_ref_low)
+    mask_full = np.array(upsample_mask(jnp.array(mask_low), w_full.shape[:2]) * jnp.array(mask_ref, dtype=jnp.float32))
+
+    return MaskTrainResult(mask_low=mask_low, mask_full=mask_full, objective_log=logs)

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_nulls.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_nulls.py
@@ -1,0 +1,417 @@
+"""
+Null distributions + stability testing for ROI discovery.
+
+NULL 1 (required): Label permutation significance (selection-aware).
+NULL 3 (required): Bootstrap stability at FIXED (λ,μ).
+
+Follows the permutation testing patterns from
+src/analyze/difference_detection/permutation_utils.py
+(compute_pvalue, PermutationResult).
+
+See PLAN.md Section F for specification.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from roi_config import NullConfig, SweepConfig, TrainerConfig
+from roi_trainer import TrainResult, extract_roi, train
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PermutationNullResult:
+    """Result from NULL 1: label permutation test."""
+    observed_auroc: float
+    null_aurocs: np.ndarray         # (n_permute,)
+    pvalue: float
+    selection_rule: str
+    observed_lam: float
+    observed_mu: float
+
+
+@dataclass
+class BootstrapStabilityResult:
+    """Result from NULL 3: bootstrap stability at fixed (λ,μ)."""
+    lam: float
+    mu: float
+    iou_distribution: np.ndarray    # (n_boot,) pairwise IoU with reference ROI
+    iou_mean: float
+    iou_std: float
+    area_fraction_distribution: np.ndarray
+    n_components_distribution: np.ndarray
+    boundary_fraction_distribution: np.ndarray
+    reference_roi: np.ndarray       # (H, W) bool — the "reference" ROI from full data
+
+
+@dataclass
+class NullsResult:
+    """Combined null testing results."""
+    permutation: Optional[PermutationNullResult]
+    bootstrap: Optional[BootstrapStabilityResult]
+
+
+# ---------------------------------------------------------------------------
+# NULL 1: Label permutation (selection-aware)
+# ---------------------------------------------------------------------------
+
+def run_permutation_null(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    groups: np.ndarray,
+    observed_auroc: float,
+    observed_lam: float,
+    observed_mu: float,
+    selection_rule: str,
+    lambda_values: List[float],
+    mu_values: List[float],
+    n_permute: int = 100,
+    sweep_config: Optional[SweepConfig] = None,
+    trainer_config: Optional[TrainerConfig] = None,
+    random_seed: int = 42,
+) -> PermutationNullResult:
+    """
+    NULL 1: Selection-aware label permutation test.
+
+    For each permutation:
+    1. Permute labels at the embryo_id level.
+    2. Run the same sweep + same deterministic selection rule.
+    3. Record the selected AUROC.
+
+    The p-value is computed against this selection-aware null.
+
+    Parameters
+    ----------
+    X, y, mask_ref, groups : data arrays
+    observed_auroc : the real AUROC from the real sweep
+    observed_lam, observed_mu : selected (λ,μ) from real sweep
+    selection_rule : name of selection rule used
+    lambda_values, mu_values : sweep grid
+    n_permute : number of permutations
+    sweep_config, trainer_config : configs
+    random_seed : base seed
+
+    Returns
+    -------
+    PermutationNullResult
+    """
+    from roi_sweep import run_sweep
+
+    sweep_config = sweep_config or SweepConfig()
+    trainer_config = trainer_config or TrainerConfig()
+
+    rng = np.random.default_rng(random_seed)
+    null_aurocs = []
+
+    # Get unique embryo IDs and their labels
+    unique_groups = np.unique(groups)
+    group_to_label = {}
+    for g in unique_groups:
+        mask = groups == g
+        group_to_label[g] = y[mask][0]  # all samples from same embryo share label
+
+    for perm_i in range(n_permute):
+        logger.info(f"Permutation {perm_i + 1}/{n_permute}")
+
+        # Permute labels at embryo_id level
+        shuffled_labels = rng.permutation(list(group_to_label.values()))
+        perm_label_map = dict(zip(unique_groups, shuffled_labels))
+        y_perm = np.array([perm_label_map[g] for g in groups])
+
+        # Run full sweep with permuted labels (selection-aware)
+        try:
+            sweep_result = run_sweep(
+                X, y_perm, mask_ref, groups,
+                lambda_values=lambda_values,
+                mu_values=mu_values,
+                sweep_config=sweep_config,
+                trainer_config=trainer_config,
+            )
+            null_aurocs.append(sweep_result.selected_auroc)
+        except Exception as e:
+            logger.warning(f"Permutation {perm_i} failed: {e}")
+            null_aurocs.append(float("nan"))
+
+    null_aurocs = np.array(null_aurocs)
+    valid = np.isfinite(null_aurocs)
+
+    # p-value: (k+1)/(n+1) formula (matches permutation_utils.py convention)
+    k = np.sum(null_aurocs[valid] >= observed_auroc)
+    n_valid = int(valid.sum())
+    pvalue = (k + 1) / (n_valid + 1)
+
+    logger.info(
+        f"Permutation null: observed AUROC={observed_auroc:.4f}, "
+        f"null mean={np.nanmean(null_aurocs):.4f}, p={pvalue:.4f}"
+    )
+
+    return PermutationNullResult(
+        observed_auroc=observed_auroc,
+        null_aurocs=null_aurocs,
+        pvalue=pvalue,
+        selection_rule=selection_rule,
+        observed_lam=observed_lam,
+        observed_mu=observed_mu,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NULL 3: Bootstrap stability at fixed (λ,μ)
+# ---------------------------------------------------------------------------
+
+def run_bootstrap_stability(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    groups: np.ndarray,
+    lam: float,
+    mu: float,
+    n_boot: int = 200,
+    roi_quantile: float = 0.9,
+    trainer_config: Optional[TrainerConfig] = None,
+    random_seed: int = 42,
+) -> BootstrapStabilityResult:
+    """
+    NULL 3: Bootstrap stability at FIXED (λ,μ).
+
+    Resamples embryos with replacement within each class, fits model
+    at fixed (λ,μ), and computes ROI stability metrics.
+
+    Parameters
+    ----------
+    X, y, mask_ref, groups : data arrays
+    lam, mu : fixed penalty parameters
+    n_boot : number of bootstrap iterations
+    roi_quantile : threshold for ROI extraction
+    trainer_config : training config
+    random_seed : base seed
+
+    Returns
+    -------
+    BootstrapStabilityResult
+    """
+    from sklearn.utils.class_weight import compute_class_weight
+
+    trainer_config = trainer_config or TrainerConfig()
+    rng = np.random.default_rng(random_seed)
+
+    # First: fit reference ROI on full data
+    classes = np.unique(y)
+    weights = compute_class_weight("balanced", classes=classes, y=y)
+    cw = {int(c): float(w) for c, w in zip(classes, weights)}
+
+    ref_result = train(X, y, mask_ref, class_weights=cw, lam=lam, mu=mu, config=trainer_config)
+    ref_roi, _ = extract_roi(ref_result.w_full, mask_ref, quantile=roi_quantile)
+
+    # Bootstrap
+    ious = []
+    areas = []
+    ncomps = []
+    bfracs = []
+
+    unique_groups = np.unique(groups)
+    class_0_groups = unique_groups[[y[groups == g][0] == 0 for g in unique_groups]]
+    class_1_groups = unique_groups[[y[groups == g][0] == 1 for g in unique_groups]]
+
+    for boot_i in range(n_boot):
+        if (boot_i + 1) % 50 == 0:
+            logger.info(f"Bootstrap {boot_i + 1}/{n_boot}")
+
+        # Resample embryos with replacement within each class
+        boot_groups_0 = rng.choice(class_0_groups, size=len(class_0_groups), replace=True)
+        boot_groups_1 = rng.choice(class_1_groups, size=len(class_1_groups), replace=True)
+        boot_groups_all = np.concatenate([boot_groups_0, boot_groups_1])
+
+        # Collect samples for bootstrapped embryos
+        boot_idx = []
+        for g in boot_groups_all:
+            boot_idx.extend(np.where(groups == g)[0])
+        boot_idx = np.array(boot_idx)
+
+        X_boot = X[boot_idx]
+        y_boot = y[boot_idx]
+
+        # Fold-local class weights
+        boot_classes = np.unique(y_boot)
+        if len(boot_classes) < 2:
+            continue  # skip degenerate bootstrap
+        boot_weights = compute_class_weight("balanced", classes=boot_classes, y=y_boot)
+        boot_cw = {int(c): float(w) for c, w in zip(boot_classes, boot_weights)}
+
+        try:
+            boot_result = train(
+                X_boot, y_boot, mask_ref,
+                class_weights=boot_cw,
+                lam=lam, mu=mu,
+                config=trainer_config,
+            )
+            boot_roi, boot_stats = extract_roi(
+                boot_result.w_full, mask_ref, quantile=roi_quantile,
+            )
+
+            # IoU with reference ROI
+            intersection = (ref_roi & boot_roi).sum()
+            union = (ref_roi | boot_roi).sum()
+            iou = float(intersection) / float(union) if union > 0 else 0.0
+
+            ious.append(iou)
+            areas.append(boot_stats["area_fraction"])
+            ncomps.append(boot_stats["n_components"])
+            bfracs.append(boot_stats["boundary_fraction"])
+
+        except Exception as e:
+            logger.warning(f"Bootstrap {boot_i} failed: {e}")
+
+    ious = np.array(ious)
+    areas = np.array(areas)
+    ncomps = np.array(ncomps)
+    bfracs = np.array(bfracs)
+
+    logger.info(
+        f"Bootstrap stability: IoU={np.mean(ious):.4f}±{np.std(ious):.4f} "
+        f"(n={len(ious)} successful)"
+    )
+
+    return BootstrapStabilityResult(
+        lam=lam,
+        mu=mu,
+        iou_distribution=ious,
+        iou_mean=float(np.mean(ious)) if len(ious) > 0 else 0.0,
+        iou_std=float(np.std(ious)) if len(ious) > 0 else 0.0,
+        area_fraction_distribution=areas,
+        n_components_distribution=ncomps,
+        boundary_fraction_distribution=bfracs,
+        reference_roi=ref_roi,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Combined runner
+# ---------------------------------------------------------------------------
+
+def run_nulls(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    groups: np.ndarray,
+    observed_auroc: float,
+    selected_lam: float,
+    selected_mu: float,
+    selection_rule: str,
+    lambda_values: List[float],
+    mu_values: List[float],
+    null_config: Optional[NullConfig] = None,
+    sweep_config: Optional[SweepConfig] = None,
+    trainer_config: Optional[TrainerConfig] = None,
+) -> NullsResult:
+    """Run NULL 1 + NULL 3 based on null_config.null_mode."""
+    from roi_config import NullMode
+
+    null_config = null_config or NullConfig()
+
+    do_permute = null_config.null_mode in (NullMode.PERMUTE, NullMode.BOTH)
+    do_bootstrap = null_config.null_mode in (NullMode.BOOTSTRAP, NullMode.BOTH)
+
+    perm_result = None
+    boot_result = None
+
+    if do_permute:
+        logger.info("Running NULL 1: label permutation test...")
+        perm_result = run_permutation_null(
+            X, y, mask_ref, groups,
+            observed_auroc=observed_auroc,
+            observed_lam=selected_lam,
+            observed_mu=selected_mu,
+            selection_rule=selection_rule,
+            lambda_values=lambda_values,
+            mu_values=mu_values,
+            n_permute=null_config.n_permute,
+            sweep_config=sweep_config,
+            trainer_config=trainer_config,
+            random_seed=null_config.random_seed,
+        )
+
+    if do_bootstrap:
+        logger.info("Running NULL 3: bootstrap stability...")
+        boot_result = run_bootstrap_stability(
+            X, y, mask_ref, groups,
+            lam=selected_lam,
+            mu=selected_mu,
+            n_boot=null_config.n_boot,
+            roi_quantile=null_config.boot_roi_quantile,
+            trainer_config=trainer_config,
+            random_seed=null_config.random_seed + 1000,
+        )
+
+    return NullsResult(
+        permutation=perm_result,
+        bootstrap=boot_result,
+    )
+
+
+def save_nulls_result(result: NullsResult, out_dir: str | Path) -> None:
+    """Save null testing results to disk."""
+    import json
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {}
+
+    if result.permutation is not None:
+        p = result.permutation
+        np.save(out_dir / "null_aurocs.npy", p.null_aurocs)
+        summary["permutation"] = {
+            "observed_auroc": p.observed_auroc,
+            "pvalue": p.pvalue,
+            "null_mean": float(np.nanmean(p.null_aurocs)),
+            "null_std": float(np.nanstd(p.null_aurocs)),
+            "n_permutations": len(p.null_aurocs),
+            "selection_rule": p.selection_rule,
+            "selected_lam": p.observed_lam,
+            "selected_mu": p.observed_mu,
+        }
+
+    if result.bootstrap is not None:
+        b = result.bootstrap
+        np.save(out_dir / "bootstrap_ious.npy", b.iou_distribution)
+        np.save(out_dir / "bootstrap_reference_roi.npy", b.reference_roi)
+        summary["bootstrap"] = {
+            "lam": b.lam,
+            "mu": b.mu,
+            "iou_mean": b.iou_mean,
+            "iou_std": b.iou_std,
+            "area_fraction_mean": float(np.mean(b.area_fraction_distribution)),
+            "n_components_mean": float(np.mean(b.n_components_distribution)),
+            "boundary_fraction_mean": float(np.mean(b.boundary_fraction_distribution)),
+            "n_bootstrap": len(b.iou_distribution),
+        }
+
+    with open(out_dir / "nulls_summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    logger.info(f"Null results saved to {out_dir}")
+
+
+__all__ = [
+    "run_permutation_null",
+    "run_bootstrap_stability",
+    "run_nulls",
+    "save_nulls_result",
+    "PermutationNullResult",
+    "BootstrapStabilityResult",
+    "NullsResult",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_nulls.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_nulls.py
@@ -223,6 +223,15 @@ def run_bootstrap_stability(
     bfracs = []
 
     unique_groups = np.unique(groups)
+
+    # Validate: all samples from each embryo must share the same label
+    for g in unique_groups:
+        labels_for_g = np.unique(y[groups == g])
+        assert len(labels_for_g) == 1, (
+            f"Embryo '{g}' has mixed labels {labels_for_g}. "
+            f"All samples from one embryo must share the same class label."
+        )
+
     class_0_groups = unique_groups[[y[groups == g][0] == 0 for g in unique_groups]]
     class_1_groups = unique_groups[[y[groups == g][0] == 1 for g in unique_groups]]
 

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_occlusion.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_occlusion.py
@@ -1,0 +1,189 @@
+"""Phase 2.0 occlusion validation with OOB bootstrap evaluation."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Tuple
+
+import numpy as np
+from sklearn.metrics import roc_auc_score
+from sklearn.utils.class_weight import compute_class_weight
+
+from roi_perturbation import apply_perturbation, compute_spatial_baseline
+from roi_resampling import iter_bootstrap_groups
+from roi_trainer import compute_logits, extract_roi, train
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OcclusionEvalResult:
+    observed_gap: float
+    gap_per_sample: np.ndarray
+    delete_gap: np.ndarray
+    preserve_gap: np.ndarray
+    auroc_orig: float
+    auroc_delete: float
+    auroc_preserve: float
+
+
+@dataclass
+class BootstrapOcclusionResult:
+    bootstrap_gaps: np.ndarray
+    ci95: Tuple[float, float]
+    frac_positive: float
+    q_sensitivity: Dict[str, Dict[str, float]]
+    n_successful: int
+    n_skipped_empty_oob: int
+
+
+def evaluate_occlusion(
+    X: np.ndarray,
+    y: np.ndarray,
+    w_full: np.ndarray,
+    b: float,
+    roi_mask: np.ndarray,
+    baseline: np.ndarray,
+) -> OcclusionEvalResult:
+    z_orig = compute_logits(X, w_full, b)
+    z_delete = compute_logits(apply_perturbation(X, 1.0 - roi_mask, baseline), w_full, b)
+    z_preserve = compute_logits(apply_perturbation(X, roi_mask, baseline), w_full, b)
+
+    delete_gap = z_orig - z_delete
+    preserve_gap = z_orig - z_preserve
+    gap_per_sample = delete_gap - preserve_gap
+    observed_gap = float(np.mean(gap_per_sample))
+
+    if np.unique(y).size < 2:
+        logger.warning("Single-class evaluation set: AUROC metrics are undefined and set to NaN")
+        auroc_orig = float("nan")
+        auroc_delete = float("nan")
+        auroc_preserve = float("nan")
+    else:
+        auroc_orig = float(roc_auc_score(y, z_orig))
+        auroc_delete = float(roc_auc_score(y, z_delete))
+        auroc_preserve = float(roc_auc_score(y, z_preserve))
+
+    return OcclusionEvalResult(
+        observed_gap=observed_gap,
+        gap_per_sample=gap_per_sample,
+        delete_gap=delete_gap,
+        preserve_gap=preserve_gap,
+        auroc_orig=auroc_orig,
+        auroc_delete=auroc_delete,
+        auroc_preserve=auroc_preserve,
+    )
+
+
+def bootstrap_occlusion(
+    X: np.ndarray,
+    y: np.ndarray,
+    groups: np.ndarray,
+    mask_ref: np.ndarray,
+    channel_names: Sequence[str],
+    lam: float,
+    mu: float,
+    n_boot: int = 200,
+    roi_quantiles: Tuple[float, ...] = (0.85, 0.90, 0.95),
+    random_seed: int = 42,
+) -> BootstrapOcclusionResult:
+    gaps = []
+    q_gaps: Dict[float, list] = {q: [] for q in roi_quantiles}
+    skipped_empty = 0
+
+    for i, sample in enumerate(iter_bootstrap_groups(groups, y, n_boot=n_boot, random_seed=random_seed)):
+        if sample.oob_is_empty:
+            skipped_empty += 1
+            logger.info("Bootstrap %d skipped: empty OOB", i)
+            continue
+
+        inbag_idx = np.concatenate([np.where(groups == g)[0] for g in sample.inbag_group_ids])
+        oob_idx = np.concatenate([np.where(groups == g)[0] for g in sample.oob_group_ids])
+
+        X_in, y_in = X[inbag_idx], y[inbag_idx]
+        X_oob, y_oob = X[oob_idx], y[oob_idx]
+
+        classes = np.unique(y_in)
+        if classes.size < 2:
+            continue
+        weights = compute_class_weight("balanced", classes=classes, y=y_in)
+        cw = {int(c): float(w) for c, w in zip(classes, weights)}
+
+        fit_result = train(
+            X_in,
+            y_in,
+            mask_ref,
+            class_weights=cw,
+            lam=lam,
+            mu=mu,
+            channel_names=channel_names,
+        )
+
+        baseline = compute_spatial_baseline(
+            X_in,
+            y_in,
+            channel_names=channel_names,
+        )
+
+        for q in roi_quantiles:
+            roi_mask, _ = extract_roi(fit_result.w_full, mask_ref, quantile=q)
+            eval_result = evaluate_occlusion(X_oob, y_oob, fit_result.w_full, fit_result.b, roi_mask, baseline)
+            q_gaps[q].append(eval_result.observed_gap)
+            if np.isclose(q, 0.9):
+                gaps.append(eval_result.observed_gap)
+
+            if sample.oob_single_class:
+                logger.info("Bootstrap %d has single-class OOB; AUROC metrics are NaN by design", i)
+
+    gaps_np = np.array(gaps, dtype=float)
+    if gaps_np.size == 0:
+        ci = (float("nan"), float("nan"))
+        frac_pos = float("nan")
+    else:
+        ci = (float(np.quantile(gaps_np, 0.025)), float(np.quantile(gaps_np, 0.975)))
+        frac_pos = float(np.mean(gaps_np > 0))
+
+    q_sensitivity = {}
+    for q, vals in q_gaps.items():
+        arr = np.array(vals, dtype=float)
+        q_sensitivity[f"{q:.2f}"] = {
+            "mean_gap": float(np.nanmean(arr)) if arr.size else float("nan"),
+            "n": int(arr.size),
+        }
+
+    return BootstrapOcclusionResult(
+        bootstrap_gaps=gaps_np,
+        ci95=ci,
+        frac_positive=frac_pos,
+        q_sensitivity=q_sensitivity,
+        n_successful=int(gaps_np.size),
+        n_skipped_empty_oob=skipped_empty,
+    )
+
+
+def save_occlusion_result(result: BootstrapOcclusionResult, out_dir: str | Path) -> None:
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    np.save(out / "bootstrap_gaps.npy", result.bootstrap_gaps)
+    summary = {
+        "ci95": list(result.ci95),
+        "frac_positive": result.frac_positive,
+        "q_sensitivity": result.q_sensitivity,
+        "n_successful": result.n_successful,
+        "n_skipped_empty_oob": result.n_skipped_empty_oob,
+    }
+    with open(out / "occlusion_summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+
+__all__ = [
+    "OcclusionEvalResult",
+    "BootstrapOcclusionResult",
+    "evaluate_occlusion",
+    "bootstrap_occlusion",
+    "save_occlusion_result",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_perturbation.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_perturbation.py
@@ -1,0 +1,56 @@
+"""Perturbation primitives and fold-safe baselines for Phase 2 occlusion validation."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+import numpy as np
+
+
+def compute_spatial_baseline(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    channel_names: Sequence[str],
+    wt_label: int = 0,
+    baseline_policy: Optional[Dict[str, str]] = None,
+) -> np.ndarray:
+    """Compute per-pixel baseline B(H,W,C) using train/inbag samples only."""
+    if X_train.ndim != 4:
+        raise ValueError(f"X_train must be 4D (N,H,W,C), got shape={X_train.shape}")
+
+    baseline_policy = baseline_policy or {name: "spatial" for name in channel_names}
+    wt_mask = y_train == wt_label
+    if not np.any(wt_mask):
+        raise ValueError("No WT samples available in training data for baseline estimation")
+
+    X_wt = X_train[wt_mask]
+    baseline = np.zeros(X_train.shape[1:], dtype=np.float32)
+
+    for c, channel_name in enumerate(channel_names):
+        policy = baseline_policy.get(channel_name, "spatial")
+        if policy != "spatial":
+            raise ValueError(f"Unsupported baseline policy '{policy}' for channel '{channel_name}'")
+        baseline[:, :, c] = X_wt[:, :, :, c].mean(axis=0)
+
+    return baseline
+
+
+def apply_perturbation(X: np.ndarray, mask: np.ndarray, baseline: np.ndarray) -> np.ndarray:
+    """Apply preserve-style perturbation P(X,m)=m*X + (1-m)*B."""
+    if X.ndim != 4:
+        raise ValueError(f"X must be 4D (N,H,W,C), got {X.shape}")
+    if mask.ndim != 2:
+        raise ValueError(f"mask must be 2D (H,W), got {mask.shape}")
+    if baseline.ndim != 3:
+        raise ValueError(f"baseline must be 3D (H,W,C), got {baseline.shape}")
+
+    if X.shape[1:3] != mask.shape:
+        raise ValueError(f"mask shape mismatch: X has {X.shape[1:3]}, mask has {mask.shape}")
+    if X.shape[1:] != baseline.shape:
+        raise ValueError(f"baseline shape mismatch: X has {X.shape[1:]}, baseline has {baseline.shape}")
+
+    m = mask.astype(np.float32)
+    return m[None, :, :, None] * X + (1.0 - m[None, :, :, None]) * baseline[None, :, :, :]
+
+
+__all__ = ["compute_spatial_baseline", "apply_perturbation"]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_resampling.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_resampling.py
@@ -1,0 +1,73 @@
+"""Group-aware resampling helpers shared by ROI bootstrap routines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class BootstrapGroupSample:
+    """One bootstrap replicate at embryo/group granularity."""
+
+    inbag_group_ids: np.ndarray
+    oob_group_ids: np.ndarray
+    oob_is_empty: bool
+    oob_single_class: bool
+
+
+def iter_bootstrap_groups(
+    groups: np.ndarray,
+    y: np.ndarray,
+    n_boot: int,
+    stratify: bool = True,
+    random_seed: int = 42,
+) -> Iterator[BootstrapGroupSample]:
+    """Yield in-bag and out-of-bag group IDs for each bootstrap replicate."""
+    unique_groups = np.unique(groups)
+    if unique_groups.size == 0:
+        return
+
+    rng = np.random.default_rng(random_seed)
+
+    group_to_label = {}
+    for group_id in unique_groups:
+        labels = np.unique(y[groups == group_id])
+        if labels.size != 1:
+            raise ValueError(
+                f"Group '{group_id}' has mixed labels {labels}; expected one label per group."
+            )
+        group_to_label[group_id] = int(labels[0])
+
+    if stratify:
+        class0 = np.array([g for g in unique_groups if group_to_label[g] == 0])
+        class1 = np.array([g for g in unique_groups if group_to_label[g] == 1])
+
+    for _ in range(n_boot):
+        if stratify:
+            inbag0 = rng.choice(class0, size=len(class0), replace=True)
+            inbag1 = rng.choice(class1, size=len(class1), replace=True)
+            inbag = np.concatenate([inbag0, inbag1])
+        else:
+            inbag = rng.choice(unique_groups, size=len(unique_groups), replace=True)
+
+        inbag_unique = np.unique(inbag)
+        oob = np.array([g for g in unique_groups if g not in inbag_unique])
+
+        oob_is_empty = oob.size == 0
+        oob_single_class = False
+        if not oob_is_empty:
+            oob_labels = np.array([group_to_label[g] for g in oob])
+            oob_single_class = np.unique(oob_labels).size < 2
+
+        yield BootstrapGroupSample(
+            inbag_group_ids=inbag,
+            oob_group_ids=oob,
+            oob_is_empty=oob_is_empty,
+            oob_single_class=oob_single_class,
+        )
+
+
+__all__ = ["BootstrapGroupSample", "iter_bootstrap_groups"]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_sweep.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_sweep.py
@@ -1,0 +1,293 @@
+"""
+λ/μ sweep + deterministic selection for ROI discovery.
+
+Phase 1: coarse grid sweep to identify a sensible operating region.
+Selection via Pareto knee (recommended) or ε-best rule.
+
+See PLAN.md Section E for specification.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from itertools import product
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+from roi_config import SelectionRule, SweepConfig, TrainerConfig
+from roi_trainer import TrainResult, extract_roi, train
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SweepEntry:
+    """One row of the sweep table."""
+    lam: float
+    mu: float
+    fold: int
+    auroc: float
+    area_fraction: float
+    n_components: int
+    boundary_fraction: float
+    train_result: Optional[TrainResult] = None
+
+
+@dataclass
+class SweepResult:
+    """Full sweep output."""
+    sweep_table: pd.DataFrame
+    selected_lam: float
+    selected_mu: float
+    selected_auroc: float
+    selected_complexity: Dict
+    selection_rule: str
+    selection_metadata: Dict
+
+
+def run_sweep(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    groups: np.ndarray,
+    lambda_values: List[float],
+    mu_values: List[float],
+    sweep_config: Optional[SweepConfig] = None,
+    trainer_config: Optional[TrainerConfig] = None,
+) -> SweepResult:
+    """
+    Run λ×μ sweep with cross-validation.
+
+    For each (λ, μ) pair, trains on CV folds and records AUROC + complexity.
+
+    Parameters
+    ----------
+    X : ndarray, (N, 512, 512, C)
+    y : ndarray, (N,)
+    mask_ref : ndarray, (512, 512)
+    groups : ndarray, (N,) — embryo_id for GroupKFold
+    lambda_values, mu_values : lists of floats
+    sweep_config : SweepConfig
+    trainer_config : TrainerConfig
+
+    Returns
+    -------
+    SweepResult with full table + selected (λ, μ).
+    """
+    from sklearn.model_selection import GroupKFold
+    from sklearn.utils.class_weight import compute_class_weight
+
+    sweep_config = sweep_config or SweepConfig()
+    trainer_config = trainer_config or TrainerConfig()
+
+    n_folds = sweep_config.n_cv_folds
+    gkf = GroupKFold(n_splits=n_folds)
+    folds = list(gkf.split(X, y, groups))
+
+    entries: List[Dict] = []
+    total_combos = len(lambda_values) * len(mu_values)
+
+    for combo_i, (lam, mu) in enumerate(product(lambda_values, mu_values)):
+        logger.info(
+            f"Sweep [{combo_i + 1}/{total_combos}]: λ={lam:.2e}, μ={mu:.2e}"
+        )
+
+        fold_aurocs = []
+        fold_areas = []
+        fold_ncomp = []
+        fold_bfrac = []
+
+        for fold_i, (train_idx, val_idx) in enumerate(folds):
+            X_train, X_val = X[train_idx], X[val_idx]
+            y_train, y_val = y[train_idx], y[val_idx]
+
+            # Fold-local class weights
+            classes = np.unique(y_train)
+            weights = compute_class_weight("balanced", classes=classes, y=y_train)
+            cw = {int(c): float(w) for c, w in zip(classes, weights)}
+
+            # Train
+            result = train(
+                X_train, y_train, mask_ref,
+                class_weights=cw,
+                lam=lam, mu=mu,
+                config=trainer_config,
+            )
+
+            # Predict on validation
+            w_full = result.w_full
+            logits_val = np.sum(X_val * w_full[None, :, :, :], axis=(1, 2, 3)) + result.b
+
+            # AUROC
+            try:
+                probs = 1.0 / (1.0 + np.exp(-logits_val))
+                auroc = roc_auc_score(y_val, probs)
+            except ValueError:
+                auroc = 0.5  # single class in val fold
+
+            # ROI complexity
+            roi_mask, roi_stats = extract_roi(
+                w_full, mask_ref, quantile=sweep_config.roi_quantile,
+            )
+
+            fold_aurocs.append(auroc)
+            fold_areas.append(roi_stats["area_fraction"])
+            fold_ncomp.append(roi_stats["n_components"])
+            fold_bfrac.append(roi_stats["boundary_fraction"])
+
+        entries.append({
+            "lam": lam,
+            "mu": mu,
+            "auroc_mean": np.mean(fold_aurocs),
+            "auroc_std": np.std(fold_aurocs),
+            "area_fraction_mean": np.mean(fold_areas),
+            "n_components_mean": np.mean(fold_ncomp),
+            "boundary_fraction_mean": np.mean(fold_bfrac),
+            "auroc_folds": fold_aurocs,
+            "area_folds": fold_areas,
+        })
+
+    sweep_df = pd.DataFrame(entries)
+    logger.info(f"Sweep complete: {len(sweep_df)} (λ,μ) combinations evaluated")
+
+    # Deterministic selection
+    selected_lam, selected_mu, sel_meta = _select_lambda_mu(
+        sweep_df, sweep_config.selection_rule, sweep_config,
+    )
+
+    # Get the row for the selected (λ,μ)
+    sel_row = sweep_df[
+        (sweep_df["lam"] == selected_lam) & (sweep_df["mu"] == selected_mu)
+    ].iloc[0]
+
+    return SweepResult(
+        sweep_table=sweep_df,
+        selected_lam=selected_lam,
+        selected_mu=selected_mu,
+        selected_auroc=float(sel_row["auroc_mean"]),
+        selected_complexity={
+            "area_fraction": float(sel_row["area_fraction_mean"]),
+            "n_components": float(sel_row["n_components_mean"]),
+            "boundary_fraction": float(sel_row["boundary_fraction_mean"]),
+        },
+        selection_rule=sweep_config.selection_rule.value,
+        selection_metadata=sel_meta,
+    )
+
+
+def _select_lambda_mu(
+    sweep_df: pd.DataFrame,
+    rule: SelectionRule,
+    config: SweepConfig,
+) -> Tuple[float, float, Dict]:
+    """
+    Deterministic selection of (λ, μ) from sweep table.
+
+    Option A (PARETO_KNEE): Knee on Pareto front of AUROC vs complexity.
+    Option B (EPSILON_BEST): Smallest complexity within ε of best AUROC.
+    """
+    if rule == SelectionRule.PARETO_KNEE:
+        return _select_pareto_knee(sweep_df, config.pareto_beta)
+    elif rule == SelectionRule.EPSILON_BEST:
+        return _select_epsilon_best(sweep_df, config.epsilon_auroc)
+    else:
+        raise ValueError(f"Unknown selection rule: {rule}")
+
+
+def _select_pareto_knee(
+    df: pd.DataFrame,
+    beta: float,
+) -> Tuple[float, float, Dict]:
+    """
+    Find the knee point on the Pareto front (AUROC vs area_fraction).
+
+    Uses a simple score: score = AUROC - beta * area_fraction
+    Higher score = better trade-off.
+    """
+    df = df.copy()
+    df["pareto_score"] = df["auroc_mean"] - beta * df["area_fraction_mean"]
+
+    best_idx = df["pareto_score"].idxmax()
+    best = df.loc[best_idx]
+
+    return (
+        float(best["lam"]),
+        float(best["mu"]),
+        {
+            "rule": "pareto_knee",
+            "beta": beta,
+            "pareto_score": float(best["pareto_score"]),
+            "best_auroc_in_sweep": float(df["auroc_mean"].max()),
+        },
+    )
+
+
+def _select_epsilon_best(
+    df: pd.DataFrame,
+    epsilon: float,
+) -> Tuple[float, float, Dict]:
+    """
+    Select smallest-complexity (λ,μ) within ε of best AUROC.
+    """
+    best_auroc = df["auroc_mean"].max()
+    threshold = best_auroc - epsilon
+
+    candidates = df[df["auroc_mean"] >= threshold].copy()
+    # Among candidates, pick smallest area_fraction
+    best_idx = candidates["area_fraction_mean"].idxmin()
+    best = candidates.loc[best_idx]
+
+    return (
+        float(best["lam"]),
+        float(best["mu"]),
+        {
+            "rule": "epsilon_best",
+            "epsilon": epsilon,
+            "best_auroc_in_sweep": float(best_auroc),
+            "auroc_threshold": float(threshold),
+            "n_candidates": len(candidates),
+        },
+    )
+
+
+def save_sweep_result(result: SweepResult, out_dir: str | Path) -> None:
+    """Save sweep results to disk."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save sweep table (drop list columns for Parquet compatibility)
+    table_df = result.sweep_table.drop(columns=["auroc_folds", "area_folds"], errors="ignore")
+    table_df.to_parquet(out_dir / "sweep_table.parquet", index=False)
+    table_df.to_csv(out_dir / "sweep_table.csv", index=False)
+
+    # Save selection metadata
+    import json
+    selection_info = {
+        "selected_lam": result.selected_lam,
+        "selected_mu": result.selected_mu,
+        "selected_auroc": result.selected_auroc,
+        "selected_complexity": result.selected_complexity,
+        "selection_rule": result.selection_rule,
+        "selection_metadata": result.selection_metadata,
+    }
+    with open(out_dir / "selection.json", "w") as f:
+        json.dump(selection_info, f, indent=2)
+
+    logger.info(
+        f"Sweep saved to {out_dir}: "
+        f"selected λ={result.selected_lam:.2e}, μ={result.selected_mu:.2e}, "
+        f"AUROC={result.selected_auroc:.4f}"
+    )
+
+
+__all__ = [
+    "run_sweep",
+    "SweepEntry",
+    "SweepResult",
+    "save_sweep_result",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_sweep.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_sweep.py
@@ -20,7 +20,7 @@ import pandas as pd
 from sklearn.metrics import roc_auc_score
 
 from roi_config import SelectionRule, SweepConfig, TrainerConfig
-from roi_trainer import TrainResult, extract_roi, train
+from roi_trainer import TrainResult, compute_logits, extract_roi, train
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,7 @@ def run_sweep(
     mu_values: List[float],
     sweep_config: Optional[SweepConfig] = None,
     trainer_config: Optional[TrainerConfig] = None,
+    channel_names: Optional[Tuple[str, ...]] = None,
 ) -> SweepResult:
     """
     Run λ×μ sweep with cross-validation.
@@ -117,11 +118,12 @@ def run_sweep(
                 class_weights=cw,
                 lam=lam, mu=mu,
                 config=trainer_config,
+                channel_names=channel_names,
             )
 
             # Predict on validation
             w_full = result.w_full
-            logits_val = np.sum(X_val * w_full[None, :, :, :], axis=(1, 2, 3)) + result.b
+            logits_val = compute_logits(X_val, w_full, result.b)
 
             # AUROC
             try:

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_sweep.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_sweep.py
@@ -208,6 +208,11 @@ def _select_pareto_knee(
 
     Uses a simple score: score = AUROC - beta * area_fraction
     Higher score = better trade-off.
+
+    beta controls the AUROC-vs-simplicity trade-off:
+        beta=1.0 — equal weight to AUROC and complexity
+        beta>1.0 — prefer simpler (smaller) ROIs
+        beta<1.0 — prefer higher AUROC even if ROI is larger
     """
     df = df.copy()
     df["pareto_score"] = df["auroc_mean"] - beta * df["area_fraction_mean"]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_trainer.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_trainer.py
@@ -181,7 +181,9 @@ def train(
         f"λ={lam:.2e}, μ={mu:.2e}"
     )
 
-    # Downsample mask to learn_res for L1/TV computation
+    # Downsample mask to learn_res for L1/TV computation.
+    # order=0 (nearest-neighbor) preserves binary mask semantics —
+    # bilinear would create fractional values at mask edges.
     from scipy.ndimage import zoom
     mask_low_np = zoom(
         mask_ref.astype(np.float32),

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_trainer.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_trainer.py
@@ -1,0 +1,364 @@
+"""
+JAX trainer for weight-map regularized logistic regression.
+
+Model:
+    params: w_low (learn_res x learn_res x C), b (scalar)
+    w_full = bilinear_upsample(w_low -> 512 x 512 x C)
+    logits = <X, w_full> + b
+    loss = class_weighted_logistic + λ L1(w_low) + μ TV(w_low)
+
+Follows the JAX/Optax pattern from
+src/analyze/utils/optimal_transport/backends/ott_backend.py
+(optional JAX import, graceful fallback).
+
+See PLAN.md Section D for full specification.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+try:
+    import jax
+    import jax.numpy as jnp
+    from jax import grad, jit, value_and_grad
+    from jax.image import resize as jax_resize
+    import optax
+    _JAX_AVAILABLE = True
+except ImportError:
+    _JAX_AVAILABLE = False
+
+from roi_config import TrainerConfig
+from roi_tv import build_tv_edges
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrainResult:
+    """Result from a single training run."""
+    w_low: np.ndarray           # (learn_res, learn_res, C)
+    w_full: np.ndarray          # (512, 512, C)
+    b: float
+    objective_log: List[Dict]   # per-step objective breakdown
+    converged: bool
+    n_steps: int
+    runtime_sec: float
+    config: Dict
+
+
+def _check_jax():
+    if not _JAX_AVAILABLE:
+        raise ImportError(
+            "JAX + Optax required for ROI trainer. "
+            "Install with: pip install jax optax"
+        )
+
+
+def _upsample_bilinear(w_low: "jnp.ndarray", target_hw: Tuple[int, int]) -> "jnp.ndarray":
+    """Bilinear upsample w_low to target resolution."""
+    # w_low: (H_low, W_low, C) -> (H_out, W_out, C)
+    H_out, W_out = target_hw
+    C = w_low.shape[-1]
+    return jax_resize(w_low, (H_out, W_out, C), method="bilinear")
+
+
+def _build_objective_fn(
+    X: "jnp.ndarray",            # (N, H, W, C) float32
+    y: "jnp.ndarray",            # (N,) int
+    sample_weights: "jnp.ndarray",  # (N,) float32
+    mask_low: "jnp.ndarray",     # (H_low, W_low) bool
+    edges_src: "jnp.ndarray",    # (E,)
+    edges_tgt: "jnp.ndarray",    # (E,)
+    output_hw: Tuple[int, int],
+    lam: float,
+    mu: float,
+):
+    """
+    Build the JIT-compiled objective function.
+
+    Returns a function f(params) -> (total_loss, aux_dict).
+    """
+    lam_jnp = jnp.float32(lam)
+    mu_jnp = jnp.float32(mu)
+
+    def objective(params):
+        w_low = params["w_low"]   # (H_low, W_low, C)
+        b = params["b"]           # scalar
+
+        # Upsample to full resolution
+        w_full = _upsample_bilinear(w_low, output_hw)  # (H, W, C)
+
+        # Compute logits: <X, w_full> + b
+        # X: (N, H, W, C), w_full: (H, W, C) -> dot product over (H, W, C)
+        logits = jnp.sum(X * w_full[None, :, :, :], axis=(1, 2, 3)) + b  # (N,)
+
+        # Class-weighted logistic loss
+        y_float = y.astype(jnp.float32)
+        log_sigmoid = jax.nn.log_sigmoid
+        per_sample_loss = -(
+            y_float * log_sigmoid(logits)
+            + (1.0 - y_float) * log_sigmoid(-logits)
+        )
+        logistic_loss = jnp.sum(per_sample_loss * sample_weights) / jnp.sum(sample_weights)
+
+        # L1 on w_low (only inside mask)
+        w_low_masked = w_low * mask_low[:, :, None]
+        l1_raw = jnp.sum(jnp.abs(w_low_masked))
+
+        # TV on w_low (mask-aware edges)
+        H_low, W_low, C = w_low.shape
+        w_flat = w_low.reshape(H_low * W_low, C)
+        diffs = w_flat[edges_src] - w_flat[edges_tgt]  # (E, C)
+        tv_raw = jnp.sum(jnp.abs(diffs))
+
+        # Total objective
+        l1_weighted = lam_jnp * l1_raw
+        tv_weighted = mu_jnp * tv_raw
+        total = logistic_loss + l1_weighted + tv_weighted
+
+        aux = {
+            "logistic_loss_raw": logistic_loss,
+            "l1_raw": l1_raw,
+            "tv_raw": tv_raw,
+            "l1_weighted": l1_weighted,
+            "tv_weighted": tv_weighted,
+            "total_objective": total,
+        }
+
+        return total, aux
+
+    return objective
+
+
+def train(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    class_weights: Dict[int, float],
+    lam: float,
+    mu: float,
+    config: Optional[TrainerConfig] = None,
+) -> TrainResult:
+    """
+    Train weight-map logistic regression with L1 + TV regularization.
+
+    Parameters
+    ----------
+    X : ndarray, shape (N, 512, 512, C)
+        Feature maps on canonical grid.
+    y : ndarray, shape (N,)
+        Binary labels (0/1).
+    mask_ref : ndarray, shape (512, 512)
+        Reference mask on canonical grid.
+    class_weights : dict
+        {0: weight_for_class_0, 1: weight_for_class_1}
+        Computed from training fold via sklearn balanced weights.
+    lam : float
+        L1 penalty strength.
+    mu : float
+        TV penalty strength.
+    config : TrainerConfig, optional
+        Training hyperparameters.
+
+    Returns
+    -------
+    TrainResult with trained weights and objective log.
+    """
+    _check_jax()
+
+    config = config or TrainerConfig()
+    N, H_out, W_out, C = X.shape
+    learn_res = config.learn_res
+
+    logger.info(
+        f"Training: N={N}, C={C}, learn_res={learn_res}, "
+        f"λ={lam:.2e}, μ={mu:.2e}"
+    )
+
+    # Downsample mask to learn_res for L1/TV computation
+    from scipy.ndimage import zoom
+    mask_low_np = zoom(
+        mask_ref.astype(np.float32),
+        (learn_res / H_out, learn_res / W_out),
+        order=0,
+    ) > 0.5
+    mask_low_np = mask_low_np.astype(np.float32)
+
+    # Build TV edges at learn_res
+    edges_src_np, edges_tgt_np = build_tv_edges(mask_low_np.astype(bool))
+
+    # Compute per-sample weights from class weights
+    sample_weights_np = np.array(
+        [class_weights.get(int(yi), 1.0) for yi in y],
+        dtype=np.float32,
+    )
+
+    # Move to JAX
+    X_jnp = jnp.array(X, dtype=jnp.float32)
+    y_jnp = jnp.array(y, dtype=jnp.int32)
+    sample_weights_jnp = jnp.array(sample_weights_np, dtype=jnp.float32)
+    mask_low_jnp = jnp.array(mask_low_np, dtype=jnp.float32)
+    edges_src_jnp = jnp.array(edges_src_np, dtype=jnp.int32)
+    edges_tgt_jnp = jnp.array(edges_tgt_np, dtype=jnp.int32)
+
+    # Build objective
+    objective_fn = _build_objective_fn(
+        X_jnp, y_jnp, sample_weights_jnp,
+        mask_low_jnp, edges_src_jnp, edges_tgt_jnp,
+        output_hw=(H_out, W_out),
+        lam=lam, mu=mu,
+    )
+
+    # Initialize params
+    rng = jax.random.PRNGKey(config.random_seed)
+    params = {
+        "w_low": jnp.zeros((learn_res, learn_res, C), dtype=jnp.float32),
+        "b": jnp.float32(0.0),
+    }
+
+    # Optimizer
+    optimizer = optax.adam(config.learning_rate)
+    opt_state = optimizer.init(params)
+
+    # JIT-compiled train step
+    @jit
+    def train_step(params, opt_state):
+        (loss, aux), grads = value_and_grad(objective_fn, has_aux=True)(params)
+        updates, new_opt_state = optimizer.update(grads, opt_state, params)
+        new_params = optax.apply_updates(params, updates)
+        return new_params, new_opt_state, loss, aux
+
+    # Training loop
+    objective_log = []
+    converged = False
+    prev_loss = float("inf")
+    t_start = time.time()
+
+    for step in range(config.max_steps):
+        params, opt_state, loss, aux = train_step(params, opt_state)
+
+        if step % config.log_every == 0 or step == config.max_steps - 1:
+            log_entry = {
+                "step": step,
+                **{k: float(v) for k, v in aux.items()},
+            }
+            objective_log.append(log_entry)
+
+            if step % (config.log_every * 5) == 0:
+                logger.info(
+                    f"  step {step:5d}: total={float(loss):.6f}, "
+                    f"logistic={float(aux['logistic_loss_raw']):.6f}, "
+                    f"L1={float(aux['l1_weighted']):.6f}, "
+                    f"TV={float(aux['tv_weighted']):.6f}"
+                )
+
+        # Convergence check
+        current_loss = float(loss)
+        if abs(prev_loss - current_loss) < config.convergence_tol:
+            converged = True
+            logger.info(f"Converged at step {step} (Δloss < {config.convergence_tol})")
+            break
+        prev_loss = current_loss
+
+    runtime = time.time() - t_start
+
+    # Extract final weights
+    w_low_np = np.array(params["w_low"])
+    w_full_np = np.array(
+        _upsample_bilinear(params["w_low"], (H_out, W_out))
+    )
+    b_np = float(params["b"])
+
+    return TrainResult(
+        w_low=w_low_np,
+        w_full=w_full_np,
+        b=b_np,
+        objective_log=objective_log,
+        converged=converged,
+        n_steps=step + 1,
+        runtime_sec=runtime,
+        config={
+            "learn_res": learn_res,
+            "output_res": H_out,
+            "lam": lam,
+            "mu": mu,
+            "learning_rate": config.learning_rate,
+            "max_steps": config.max_steps,
+            "class_weights": class_weights,
+        },
+    )
+
+
+def extract_roi(
+    w_full: np.ndarray,
+    mask_ref: np.ndarray,
+    quantile: float = 0.9,
+) -> Tuple[np.ndarray, Dict]:
+    """
+    Extract ROI from trained weight map via quantile thresholding.
+
+    Parameters
+    ----------
+    w_full : ndarray, shape (H, W, C)
+        Full-resolution weight map.
+    mask_ref : ndarray, shape (H, W)
+        Reference mask.
+    quantile : float
+        Threshold |w| at this quantile (within mask).
+
+    Returns
+    -------
+    roi_mask : ndarray, shape (H, W), bool
+        Binary ROI mask.
+    roi_stats : dict
+        area_fraction, n_components, boundary_fraction
+    """
+    from scipy.ndimage import label as ndimage_label
+    from roi_tv import compute_boundary_fraction
+
+    # Magnitude across channels
+    w_mag = np.sqrt(np.sum(w_full ** 2, axis=-1))  # (H, W)
+
+    # Only consider pixels inside the reference mask
+    mask_bool = mask_ref.astype(bool)
+    w_mag_masked = w_mag * mask_bool
+
+    # Threshold at quantile
+    values_in_mask = w_mag_masked[mask_bool]
+    if len(values_in_mask) == 0:
+        roi_mask = np.zeros_like(mask_bool)
+        return roi_mask, {"area_fraction": 0.0, "n_components": 0, "boundary_fraction": 0.0}
+
+    threshold = np.quantile(values_in_mask, quantile)
+    roi_mask = (w_mag_masked > threshold) & mask_bool
+
+    # Compute stats
+    mask_area = mask_bool.sum()
+    roi_area = roi_mask.sum()
+    area_fraction = float(roi_area) / float(mask_area) if mask_area > 0 else 0.0
+
+    labeled, n_components = ndimage_label(roi_mask)
+    boundary_frac = compute_boundary_fraction(roi_mask, mask_ref)
+
+    roi_stats = {
+        "area_fraction": area_fraction,
+        "n_components": n_components,
+        "boundary_fraction": boundary_frac,
+        "threshold": float(threshold),
+        "quantile": quantile,
+    }
+
+    return roi_mask, roi_stats
+
+
+__all__ = [
+    "train",
+    "extract_roi",
+    "TrainResult",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_tv.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_tv.py
@@ -1,0 +1,200 @@
+"""
+Total Variation with mask-aware boundary behavior.
+
+TV is defined over edges in a 4-neighborhood graph. An edge (p, q) is
+included ONLY if both p and q are inside mask_ref. This means:
+- No zero-padding outside the embryo mask
+- Boundary pixels have fewer valid neighbors ("reduced-degree boundary")
+
+This module provides both a NumPy reference implementation and a
+JAX-compatible implementation for use in the differentiable trainer.
+
+See PLAN.md Section C for the full specification.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+try:
+    import jax
+    import jax.numpy as jnp
+    _JAX_AVAILABLE = True
+except ImportError:
+    _JAX_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Edge list construction (NumPy, run once at setup)
+# ---------------------------------------------------------------------------
+
+def build_tv_edges(
+    mask: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Build the list of valid TV edges from a binary mask.
+
+    An edge connects pixel p to pixel q in the 4-neighborhood
+    if and only if both p and q are inside the mask.
+
+    Parameters
+    ----------
+    mask : ndarray, shape (H, W), bool or uint8
+        Reference embryo mask. Nonzero = inside.
+
+    Returns
+    -------
+    edges_src : ndarray, shape (E,), int
+        Flat indices of edge source pixels.
+    edges_tgt : ndarray, shape (E,), int
+        Flat indices of edge target pixels.
+    """
+    mask_bool = mask.astype(bool)
+    H, W = mask_bool.shape
+
+    src_list = []
+    tgt_list = []
+
+    # Horizontal edges: (i, j) <-> (i, j+1)
+    valid_h = mask_bool[:, :-1] & mask_bool[:, 1:]
+    rows, cols = np.where(valid_h)
+    src_flat = rows * W + cols
+    tgt_flat = rows * W + (cols + 1)
+    src_list.append(src_flat)
+    tgt_list.append(tgt_flat)
+
+    # Vertical edges: (i, j) <-> (i+1, j)
+    valid_v = mask_bool[:-1, :] & mask_bool[1:, :]
+    rows, cols = np.where(valid_v)
+    src_flat = rows * W + cols
+    tgt_flat = (rows + 1) * W + cols
+    src_list.append(src_flat)
+    tgt_list.append(tgt_flat)
+
+    edges_src = np.concatenate(src_list)
+    edges_tgt = np.concatenate(tgt_list)
+
+    return edges_src, edges_tgt
+
+
+def compute_tv_numpy(
+    w: np.ndarray,
+    mask: np.ndarray,
+) -> float:
+    """
+    Compute anisotropic TV of w restricted to mask edges (NumPy reference).
+
+    TV(w) = sum_{(p,q) in edges} |w_p - w_q|
+
+    For multi-channel w, sums across channels.
+
+    Parameters
+    ----------
+    w : ndarray, shape (H, W) or (H, W, C)
+        Weight map.
+    mask : ndarray, shape (H, W)
+        Reference mask.
+
+    Returns
+    -------
+    float
+        Total variation value.
+    """
+    edges_src, edges_tgt = build_tv_edges(mask)
+
+    if w.ndim == 2:
+        w_flat = w.ravel()
+        return float(np.sum(np.abs(w_flat[edges_src] - w_flat[edges_tgt])))
+    elif w.ndim == 3:
+        H, W, C = w.shape
+        w_flat = w.reshape(H * W, C)
+        diffs = w_flat[edges_src] - w_flat[edges_tgt]  # (E, C)
+        return float(np.sum(np.abs(diffs)))
+    else:
+        raise ValueError(f"w must be 2D or 3D, got {w.ndim}D")
+
+
+def compute_boundary_fraction(
+    roi_mask: np.ndarray,
+    ref_mask: np.ndarray,
+    band_width: int = 3,
+) -> float:
+    """
+    Compute the fraction of ROI pixels that lie in a thin boundary band.
+
+    Used as a diagnostic to detect registration-driven edge artifacts.
+
+    Parameters
+    ----------
+    roi_mask : ndarray, shape (H, W), bool
+        Thresholded ROI region.
+    ref_mask : ndarray, shape (H, W), bool
+        Reference embryo mask.
+    band_width : int
+        Width of the boundary band in pixels.
+
+    Returns
+    -------
+    float
+        Fraction of ROI pixels in the boundary band (0.0 to 1.0).
+    """
+    from scipy.ndimage import binary_erosion
+
+    ref_bool = ref_mask.astype(bool)
+    roi_bool = roi_mask.astype(bool)
+
+    interior = binary_erosion(ref_bool, iterations=band_width)
+    boundary_band = ref_bool & ~interior
+
+    roi_area = roi_bool.sum()
+    if roi_area == 0:
+        return 0.0
+
+    roi_in_boundary = (roi_bool & boundary_band).sum()
+    return float(roi_in_boundary) / float(roi_area)
+
+
+# ---------------------------------------------------------------------------
+# JAX-compatible TV (for differentiable training)
+# ---------------------------------------------------------------------------
+
+if _JAX_AVAILABLE:
+    def compute_tv_jax(
+        w_flat: jnp.ndarray,
+        edges_src: jnp.ndarray,
+        edges_tgt: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """
+        JAX-compatible anisotropic TV using precomputed edge indices.
+
+        Parameters
+        ----------
+        w_flat : jnp array, shape (H*W,) or (H*W, C)
+            Flattened weight map.
+        edges_src : jnp array, shape (E,), int
+            Edge source indices.
+        edges_tgt : jnp array, shape (E,), int
+            Edge target indices.
+
+        Returns
+        -------
+        Scalar TV value (differentiable).
+        """
+        if w_flat.ndim == 1:
+            diffs = w_flat[edges_src] - w_flat[edges_tgt]
+            return jnp.sum(jnp.abs(diffs))
+        else:
+            diffs = w_flat[edges_src] - w_flat[edges_tgt]  # (E, C)
+            return jnp.sum(jnp.abs(diffs))
+
+
+__all__ = [
+    "build_tv_edges",
+    "compute_tv_numpy",
+    "compute_boundary_fraction",
+]
+
+if _JAX_AVAILABLE:
+    __all__.append("compute_tv_jax")

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_viz.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/roi_viz.py
@@ -1,0 +1,453 @@
+"""
+Visualization for ROI discovery results.
+
+Provides:
+- Weight map heatmaps (magnitude on canonical grid)
+- ROI contour overlays on reference mask
+- Sweep Pareto front plots
+- Null distribution histograms
+- Bootstrap IoU distribution plots
+- Objective convergence curves
+
+Follows the plotting patterns from:
+- src/analyze/optimal_transport_morphometrics/uot_masks/viz.py (heatmaps, overlays)
+- src/analyze/difference_detection/classification_test_viz.py (AUROC plots)
+- src/analyze/viz/styling/ (color palettes)
+
+NOTE: Some integration with the existing viz infrastructure
+(e.g., resolve_color_lookup, faceting_engine) is deferred until
+the ROI results are validated and the pipeline is mature.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize
+from matplotlib.patches import Patch
+import matplotlib.cm as cm
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Display helpers (match UOT viz convention)
+# ---------------------------------------------------------------------------
+
+def _plot_extent(hw: Tuple[int, int]) -> Tuple[list, str]:
+    """Return extent and origin for image display mode."""
+    h, w = hw
+    return [0, w, h, 0], "upper"
+
+
+# ---------------------------------------------------------------------------
+# Weight map visualization
+# ---------------------------------------------------------------------------
+
+def plot_weight_map(
+    w_full: np.ndarray,
+    mask_ref: np.ndarray,
+    title: str = "Weight Map Magnitude",
+    cmap: str = "inferno",
+    ax: Optional[plt.Axes] = None,
+    save_path: Optional[str] = None,
+) -> plt.Axes:
+    """
+    Plot the magnitude of the trained weight map on the canonical grid.
+
+    Parameters
+    ----------
+    w_full : ndarray, (H, W, C)
+        Full-resolution weight map.
+    mask_ref : ndarray, (H, W)
+        Reference embryo mask.
+    title : str
+    cmap : str
+    ax : matplotlib Axes, optional
+    save_path : str, optional
+
+    Returns
+    -------
+    matplotlib Axes
+    """
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+    else:
+        fig = ax.figure
+
+    w_mag = np.sqrt(np.sum(w_full ** 2, axis=-1))  # (H, W)
+
+    # Mask outside embryo
+    w_display = np.where(mask_ref.astype(bool), w_mag, np.nan)
+
+    H, W = w_display.shape
+    extent, origin = _plot_extent((H, W))
+    im = ax.imshow(w_display, cmap=cmap, extent=extent, origin=origin,
+                   interpolation="bilinear")
+    plt.colorbar(im, ax=ax, label="|w|", shrink=0.8)
+
+    ax.set_title(title)
+    ax.set_xlabel("x (pixels)")
+    ax.set_ylabel("y (pixels)")
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved weight map: {save_path}")
+
+    return ax
+
+
+def plot_roi_overlay(
+    roi_mask: np.ndarray,
+    mask_ref: np.ndarray,
+    w_full: Optional[np.ndarray] = None,
+    title: str = "ROI Overlay",
+    roi_color: str = "red",
+    roi_alpha: float = 0.4,
+    show_contour: bool = True,
+    ax: Optional[plt.Axes] = None,
+    save_path: Optional[str] = None,
+) -> plt.Axes:
+    """
+    Plot ROI overlaid on the reference mask, optionally with weight heatmap.
+
+    Parameters
+    ----------
+    roi_mask : ndarray, (H, W), bool
+        Binary ROI mask.
+    mask_ref : ndarray, (H, W)
+        Reference embryo mask.
+    w_full : ndarray, (H, W, C), optional
+        If provided, show weight magnitude as background heatmap.
+    title : str
+    roi_color : str
+    roi_alpha : float
+    show_contour : bool
+    ax : matplotlib Axes, optional
+    save_path : str, optional
+    """
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+    else:
+        fig = ax.figure
+
+    H, W = mask_ref.shape
+    extent, origin = _plot_extent((H, W))
+
+    # Background: either weight map or plain mask
+    if w_full is not None:
+        w_mag = np.sqrt(np.sum(w_full ** 2, axis=-1))
+        bg = np.where(mask_ref.astype(bool), w_mag, np.nan)
+        ax.imshow(bg, cmap="gray", extent=extent, origin=origin,
+                  interpolation="bilinear", alpha=0.6)
+    else:
+        ax.imshow(mask_ref.astype(float), cmap="gray", extent=extent,
+                  origin=origin, alpha=0.3)
+
+    # ROI overlay
+    roi_display = np.zeros((*roi_mask.shape, 4), dtype=float)
+    color_rgb = matplotlib.colors.to_rgb(roi_color)
+    roi_display[roi_mask, :3] = color_rgb
+    roi_display[roi_mask, 3] = roi_alpha
+    ax.imshow(roi_display, extent=extent, origin=origin, interpolation="nearest")
+
+    # Contour
+    if show_contour:
+        ax.contour(roi_mask.astype(float), levels=[0.5],
+                   colors=[roi_color], linewidths=1.5,
+                   extent=extent, origin=origin)
+
+    ax.set_title(title)
+    ax.set_xlabel("x (pixels)")
+    ax.set_ylabel("y (pixels)")
+
+    # Legend
+    patches = [
+        Patch(facecolor=roi_color, alpha=roi_alpha, label="ROI"),
+        Patch(facecolor="gray", alpha=0.3, label="Embryo mask"),
+    ]
+    ax.legend(handles=patches, loc="upper right")
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved ROI overlay: {save_path}")
+
+    return ax
+
+
+# ---------------------------------------------------------------------------
+# Sweep visualization
+# ---------------------------------------------------------------------------
+
+def plot_sweep_pareto(
+    sweep_df: pd.DataFrame,
+    selected_lam: Optional[float] = None,
+    selected_mu: Optional[float] = None,
+    title: str = "Sweep: AUROC vs ROI Complexity",
+    ax: Optional[plt.Axes] = None,
+    save_path: Optional[str] = None,
+) -> plt.Axes:
+    """
+    Plot the Pareto front from the λ/μ sweep.
+
+    Parameters
+    ----------
+    sweep_df : DataFrame
+        Sweep table with columns: lam, mu, auroc_mean, area_fraction_mean.
+    selected_lam, selected_mu : float, optional
+        Highlight the selected (λ, μ) point.
+    """
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(8, 6))
+    else:
+        fig = ax.figure
+
+    scatter = ax.scatter(
+        sweep_df["area_fraction_mean"],
+        sweep_df["auroc_mean"],
+        c=np.log10(sweep_df["lam"]),
+        cmap="viridis",
+        s=80,
+        edgecolors="k",
+        linewidths=0.5,
+    )
+    plt.colorbar(scatter, ax=ax, label="log10(λ)")
+    ax.set_xlabel("Area Fraction (complexity)")
+    ax.set_ylabel("AUROC")
+    ax.set_title(title)
+
+    if selected_lam is not None and selected_mu is not None:
+        sel_row = sweep_df[
+            (np.isclose(sweep_df["lam"], selected_lam))
+            & (np.isclose(sweep_df["mu"], selected_mu))
+        ]
+        if len(sel_row) > 0:
+            ax.scatter(
+                sel_row["area_fraction_mean"],
+                sel_row["auroc_mean"],
+                marker="*", s=300, c="red", zorder=5,
+                label=f"Selected (λ={selected_lam:.2e})",
+            )
+            ax.legend()
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+
+    return ax
+
+
+# ---------------------------------------------------------------------------
+# Null distribution visualization
+# ---------------------------------------------------------------------------
+
+def plot_null_distribution(
+    null_aurocs: np.ndarray,
+    observed_auroc: float,
+    pvalue: float,
+    title: str = "Label Permutation Null",
+    ax: Optional[plt.Axes] = None,
+    save_path: Optional[str] = None,
+) -> plt.Axes:
+    """
+    Histogram of null AUROC distribution with observed value marked.
+
+    Mirrors the style of plot_auroc_with_null from
+    src/analyze/difference_detection/classification_test_viz.py.
+    """
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+    else:
+        fig = ax.figure
+
+    valid = null_aurocs[np.isfinite(null_aurocs)]
+    ax.hist(valid, bins=30, alpha=0.7, color="steelblue", edgecolor="k",
+            label="Null distribution")
+    ax.axvline(observed_auroc, color="red", linewidth=2, linestyle="--",
+               label=f"Observed AUROC={observed_auroc:.4f}\np={pvalue:.4f}")
+
+    ax.set_xlabel("AUROC (selection-aware null)")
+    ax.set_ylabel("Count")
+    ax.set_title(title)
+    ax.legend()
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+
+    return ax
+
+
+def plot_bootstrap_iou(
+    iou_distribution: np.ndarray,
+    title: str = "Bootstrap ROI Stability",
+    ax: Optional[plt.Axes] = None,
+    save_path: Optional[str] = None,
+) -> plt.Axes:
+    """Histogram of bootstrap IoU distribution."""
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+    else:
+        fig = ax.figure
+
+    mean_iou = np.mean(iou_distribution)
+    std_iou = np.std(iou_distribution)
+
+    ax.hist(iou_distribution, bins=30, alpha=0.7, color="darkorange", edgecolor="k")
+    ax.axvline(mean_iou, color="red", linewidth=2,
+               label=f"Mean IoU={mean_iou:.4f}±{std_iou:.4f}")
+
+    ax.set_xlabel("IoU with Reference ROI")
+    ax.set_ylabel("Count")
+    ax.set_title(title)
+    ax.legend()
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+
+    return ax
+
+
+# ---------------------------------------------------------------------------
+# Training diagnostics
+# ---------------------------------------------------------------------------
+
+def plot_objective_curve(
+    objective_log: list,
+    title: str = "Training Objective",
+    ax: Optional[plt.Axes] = None,
+    save_path: Optional[str] = None,
+) -> plt.Axes:
+    """
+    Plot training objective components over steps.
+
+    Shows total, logistic, L1, and TV components.
+    """
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(10, 5))
+    else:
+        fig = ax.figure
+
+    df = pd.DataFrame(objective_log)
+
+    ax.plot(df["step"], df["total_objective"], "k-", linewidth=2, label="Total")
+    ax.plot(df["step"], df["logistic_loss_raw"], "b--", label="Logistic")
+    ax.plot(df["step"], df["l1_weighted"], "r--", label="λ·L1")
+    ax.plot(df["step"], df["tv_weighted"], "g--", label="μ·TV")
+
+    ax.set_xlabel("Step")
+    ax.set_ylabel("Objective")
+    ax.set_title(title)
+    ax.legend()
+    ax.set_yscale("log")
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+
+    return ax
+
+
+# ---------------------------------------------------------------------------
+# Full report figure
+# ---------------------------------------------------------------------------
+
+def plot_full_report(
+    run_dir: str,
+    save_path: Optional[str] = None,
+) -> plt.Figure:
+    """
+    Generate a multi-panel summary figure for a completed ROI run.
+
+    Panels:
+    1. Weight map heatmap
+    2. ROI overlay
+    3. Sweep Pareto front
+    4. Null distribution
+    5. Bootstrap IoU
+    6. Objective convergence
+
+    This is a convenience wrapper that loads data from the run directory.
+    """
+    run_path = Path(run_dir)
+    fig, axes = plt.subplots(2, 3, figsize=(20, 12))
+    fig.suptitle(f"ROI Discovery Report: {run_path.name}", fontsize=14, fontweight="bold")
+
+    # Load what's available and fill panels
+    panels_filled = 0
+
+    # Panel 1-2: Weight map + ROI (need trained model output — placeholder)
+    axes[0, 0].text(0.5, 0.5, "Weight Map\n(requires trained model)",
+                    ha="center", va="center", transform=axes[0, 0].transAxes)
+    axes[0, 0].set_title("Weight Map |w|")
+
+    axes[0, 1].text(0.5, 0.5, "ROI Overlay\n(requires trained model)",
+                    ha="center", va="center", transform=axes[0, 1].transAxes)
+    axes[0, 1].set_title("ROI on Reference Mask")
+
+    # Panel 3: Sweep Pareto
+    sweep_csv = run_path / "sweep" / "sweep_table.csv"
+    sel_json = run_path / "sweep" / "selection.json"
+    if sweep_csv.exists():
+        sweep_df = pd.read_csv(sweep_csv)
+        sel_lam, sel_mu = None, None
+        if sel_json.exists():
+            with open(sel_json) as f:
+                sel = json.load(f)
+            sel_lam = sel.get("selected_lam")
+            sel_mu = sel.get("selected_mu")
+        plot_sweep_pareto(sweep_df, sel_lam, sel_mu, ax=axes[0, 2])
+        panels_filled += 1
+
+    # Panel 4: Null distribution
+    null_npy = run_path / "nulls" / "null_aurocs.npy"
+    nulls_json = run_path / "nulls" / "nulls_summary.json"
+    if null_npy.exists() and nulls_json.exists():
+        null_aurocs = np.load(null_npy)
+        with open(nulls_json) as f:
+            ns = json.load(f)
+        if "permutation" in ns:
+            plot_null_distribution(
+                null_aurocs,
+                ns["permutation"]["observed_auroc"],
+                ns["permutation"]["pvalue"],
+                ax=axes[1, 0],
+            )
+            panels_filled += 1
+
+    # Panel 5: Bootstrap IoU
+    iou_npy = run_path / "nulls" / "bootstrap_ious.npy"
+    if iou_npy.exists():
+        ious = np.load(iou_npy)
+        plot_bootstrap_iou(ious, ax=axes[1, 1])
+        panels_filled += 1
+
+    # Panel 6: placeholder for convergence
+    axes[1, 2].text(0.5, 0.5, "Objective Convergence\n(requires training log)",
+                    ha="center", va="center", transform=axes[1, 2].transAxes)
+    axes[1, 2].set_title("Training Convergence")
+
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved full report: {save_path}")
+
+    return fig
+
+
+__all__ = [
+    "plot_weight_map",
+    "plot_roi_overlay",
+    "plot_sweep_pareto",
+    "plot_null_distribution",
+    "plot_bootstrap_iou",
+    "plot_objective_curve",
+    "plot_full_report",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/run_roi_discovery.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/run_roi_discovery.py
@@ -1,0 +1,214 @@
+"""
+Example driver script for ROI discovery.
+
+This script demonstrates the end-to-end pipeline:
+1. Build a FeatureDataset from OT results (or load existing)
+2. Run the ROI discovery sweep
+3. Run null tests
+4. Generate plots and report
+
+Usage:
+    python run_roi_discovery.py
+
+Before running:
+    - Ensure OT results exist from the UOT pipeline
+      (see results/mcolon/20260121_uot-mvp/)
+    - A FeatureDataset must be built first (see build_dataset() below)
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Add morphseq root to path for imports
+MORPHSEQ_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(MORPHSEQ_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from roi_config import ROIRunConfig, FeatureSet
+from roi_api import fit, plot, report
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Path to OT pair results from the UOT MVP pipeline
+OT_RESULTS_CSV = (
+    MORPHSEQ_ROOT
+    / "results"
+    / "mcolon"
+    / "20251229_cep290_phenotype_extraction"
+    / "final_data"
+    / "embryo_data_with_labels.csv"
+)
+
+# Output paths
+SCRIPT_DIR = Path(__file__).parent
+DATASET_DIR = SCRIPT_DIR / "roi_feature_dataset_cep290"
+
+
+# ---------------------------------------------------------------------------
+# Step 0: Build FeatureDataset (run once, then reuse)
+# ---------------------------------------------------------------------------
+
+def build_dataset_from_ot_results():
+    """
+    Build a FeatureDataset from existing OT transport results.
+
+    This function demonstrates how to extract canonical-grid feature maps
+    from the UOT pipeline output and package them into the FeatureDataset
+    contract.
+
+    NOTE: This is a TEMPLATE. The actual implementation will depend on
+    the specific format of your OT results. The key requirement is to
+    produce:
+        X:      (N, 512, 512, C) float32 feature maps
+        y:      (N,) int labels (0=WT, 1=cep290)
+        mask:   (512, 512) reference mask
+        meta:   DataFrame with embryo_id, genotype columns
+        costs:  (N,) total OT cost per sample
+    """
+    import pandas as pd
+    from roi_feature_dataset import FeatureDatasetBuilder
+
+    logger.info("Building FeatureDataset from OT results...")
+    logger.info(f"  Source: {OT_RESULTS_CSV}")
+
+    # ------------------------------------------------------------------
+    # TODO: Replace this section with actual data loading from your
+    # OT pipeline outputs. The code below is a structural template
+    # showing the expected data shapes and types.
+    #
+    # In practice, you would:
+    # 1. Load OT results (UOTResult objects or saved arrays)
+    # 2. Extract canonical-grid maps (cost, velocity, mass creation)
+    # 3. Stack into (N, 512, 512, C) array
+    # 4. Build label vector from genotype metadata
+    # ------------------------------------------------------------------
+
+    # Check if source data exists
+    if not OT_RESULTS_CSV.exists():
+        logger.warning(
+            f"Source data not found: {OT_RESULTS_CSV}\n"
+            "Cannot build dataset without OT results.\n"
+            "Run the UOT pipeline first "
+            "(see results/mcolon/20260121_uot-mvp/)."
+        )
+        return None
+
+    # Load metadata to get embryo info
+    df = pd.read_csv(OT_RESULTS_CSV)
+    logger.info(f"  Loaded metadata: {len(df)} rows")
+
+    # Identify unique embryos and their genotypes
+    if "embryo_id" in df.columns and "genotype" in df.columns:
+        embryo_info = df.groupby("embryo_id")["genotype"].first().reset_index()
+        logger.info(f"  Unique embryos: {len(embryo_info)}")
+        logger.info(f"  Genotype distribution:\n{embryo_info['genotype'].value_counts()}")
+    else:
+        logger.warning("  Required columns (embryo_id, genotype) not found")
+        return None
+
+    # ------------------------------------------------------------------
+    # TEMPLATE: This section shows the expected structure.
+    # Replace with actual feature extraction from OT results.
+    # ------------------------------------------------------------------
+    logger.info(
+        "\n"
+        "  FeatureDataset builder is ready. To complete the build:\n"
+        "  1. Extract canonical-grid OT maps for each embryo\n"
+        "     (use transport_maps.rasterize_*_to_canonical)\n"
+        "  2. Stack into X array: (N, 512, 512, C)\n"
+        "  3. Call builder.build(X, y, mask_ref, metadata_df, costs)\n"
+        "\n"
+        "  See roi_feature_dataset.py for the builder API.\n"
+    )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Run ROI discovery
+# ---------------------------------------------------------------------------
+
+def run_discovery():
+    """Run the full ROI discovery pipeline."""
+    dataset_dir = str(DATASET_DIR)
+
+    if not DATASET_DIR.exists():
+        logger.error(
+            f"FeatureDataset not found at {DATASET_DIR}\n"
+            "Run build_dataset_from_ot_results() first."
+        )
+        return None
+
+    # Run with defaults
+    result = fit(
+        dataset_dir=dataset_dir,
+        genotype="cep290",
+        features="cost",
+        learn_res=128,
+        roi_size="medium",
+        smoothness="medium",
+        null="both",
+        n_permute=100,
+        n_boot=200,
+    )
+
+    # Generate plots
+    plot(result["out_dir"])
+
+    # Print report
+    report(result["out_dir"])
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ROI Discovery via OT Feature Maps")
+    parser.add_argument(
+        "--build", action="store_true",
+        help="Build FeatureDataset from OT results",
+    )
+    parser.add_argument(
+        "--run", action="store_true",
+        help="Run ROI discovery pipeline",
+    )
+    parser.add_argument(
+        "--report", type=str, default=None,
+        help="Path to run directory for report generation",
+    )
+
+    args = parser.parse_args()
+
+    if args.build:
+        build_dataset_from_ot_results()
+    elif args.run:
+        run_discovery()
+    elif args.report:
+        plot(args.report)
+        report(args.report)
+    else:
+        # Default: show help
+        parser.print_help()
+        print("\nExample workflow:")
+        print("  python run_roi_discovery.py --build   # Build dataset first")
+        print("  python run_roi_discovery.py --run     # Run discovery pipeline")
+        print("  python run_roi_discovery.py --report <dir>  # View results")

--- a/src/analyze/difference_detection/classification_test.py
+++ b/src/analyze/difference_detection/classification_test.py
@@ -289,6 +289,7 @@ def run_binary_classification_test(
 
     if verbose:
         print(f"Comparing {group1} (n={n_group1}) vs {group2} (n={n_group2})")
+        print("Classification weighting: class_weight='balanced' (enabled by default)")
 
     # Determine feature columns
     if isinstance(features, str):
@@ -415,6 +416,12 @@ def _run_classification(
 
         n_positive = int(np.sum(y_labels == positive_label))
         n_negative = int(np.sum(y_labels == negative_label))
+
+        if verbose:
+            print(
+                f"    Class counts (positive={positive_label}: {n_positive}, "
+                f"negative={negative_label}: {n_negative}); using balanced class weights"
+            )
 
         # Check class count (must contain both positive and negative labels)
         if n_positive == 0 or n_negative == 0:

--- a/src/analyze/difference_detection/classification_test_multiclass.py
+++ b/src/analyze/difference_detection/classification_test_multiclass.py
@@ -388,6 +388,7 @@ def run_multiclass_classification_test(
 
     if verbose:
         print(f"Multiclass comparison with {n_classes} classes: {class_labels}")
+        print("Classification weighting: class_weight='balanced' (enabled by default)")
 
     # Build embryo_id -> class_label mapping
     embryo_to_class = {}
@@ -553,6 +554,9 @@ def _run_multiclass_classification(
 
         # Check class counts
         class_counts = {label: np.sum(y_labels == label) for label in class_labels}
+        if verbose:
+            print(f"    Class counts: {class_counts}")
+            print("    Using balanced class weights for this bin")
         present_classes = [label for label, count in class_counts.items() if count > 0]
         missing_classes = [label for label, count in class_counts.items() if count == 0]
 
@@ -1052,6 +1056,7 @@ def run_classification_test(
         print(f"Groupby column: {groupby}")
         print(f"Groups: {groups}")
         print(f"Reference: {reference}")
+        print("Classifier policy: class_weight='balanced' for all logistic models")
     
     # Resolve comparisons
     comparison_specs = _resolve_comparison_groups(

--- a/src/analyze/difference_detection/docs/multiclass_classification_api.md
+++ b/src/analyze/difference_detection/docs/multiclass_classification_api.md
@@ -4,6 +4,11 @@ This document shows how to use the new Scanpy-style comparison API with visualiz
 
 ## Basic Usage
 
+> **Class imbalance default:** the routed `run_classification_test()` path uses logistic regression with `class_weight='balanced'` for both binary and multiclass runs.
+>
+> **Verbose logging:** with `verbose=True` (default), the run now prints the balancing policy and per-bin class counts so balancing assumptions are explicit in logs.
+
+
 ```python
 from analyze.difference_detection import run_classification_test
 

--- a/src/analyze/difference_detection/tests/test_class_weight_logging.py
+++ b/src/analyze/difference_detection/tests/test_class_weight_logging.py
@@ -1,0 +1,69 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import pandas as pd
+
+from analyze.difference_detection.classification_test_multiclass import (
+    _make_logistic_classifier,
+    run_classification_test,
+)
+
+
+class ClassWeightPolicyTests(unittest.TestCase):
+    def test_make_logistic_classifier_uses_balanced_weights(self):
+        clf_binary = _make_logistic_classifier(n_classes=2, random_state=42)
+        clf_multi = _make_logistic_classifier(n_classes=3, random_state=42)
+
+        self.assertEqual(clf_binary.class_weight, "balanced")
+        self.assertEqual(clf_multi.class_weight, "balanced")
+
+    def test_run_classification_test_verbose_reports_balanced_policy(self):
+        df = pd.DataFrame(
+            {
+                "embryo_id": ["e1", "e2", "e3", "e4"],
+                "cluster": ["A", "A", "WT", "WT"],
+                "predicted_stage_hpf": [10.0, 10.5, 10.2, 10.7],
+                "z_mu_b_0": [0.1, 0.2, -0.1, -0.2],
+            }
+        )
+
+        fake_result = {
+            "ovr_classification": {
+                "A": pd.DataFrame(
+                    [
+                        {
+                            "time_bin": 8,
+                            "time_bin_center": 10.0,
+                            "auroc_observed": 0.75,
+                            "pval": 0.05,
+                        }
+                    ]
+                )
+            }
+        }
+
+        with patch(
+            "analyze.difference_detection.classification_test_multiclass.run_multiclass_classification_test",
+            return_value=fake_result,
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                run_classification_test(
+                    df=df,
+                    groupby="cluster",
+                    groups=["A"],
+                    reference="WT",
+                    features=["z_mu_b_0"],
+                    n_permutations=0,
+                    verbose=True,
+                )
+
+            output = buf.getvalue()
+
+        self.assertIn("Classifier policy: class_weight='balanced'", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Dated results folder with full implementation plan and backend code
for learning interpretable spatial ROIs from OT-derived canonical-grid
feature maps. Includes FeatureDataset contract (Zarr/Parquet/manifest),
streaming loader with embryo-grouped CV splits, mask-aware TV
regularization, JAX trainer (logistic + L1 + TV), lambda/mu sweep with
deterministic Pareto/epsilon selection, selection-aware permutation
nulls, fixed-(lambda,mu) bootstrap stability, visualization suite, and
biologist-facing API (fit/plot/report).

https://claude.ai/code/session_01HXzTqSxzKvp2xx8vnttE9z