### PR TITLE
Resolve PR #9 conflicts and integrate class-weight logging + ROI backend updates

### DIFF
--- a/results/mcolon/20251016/CLASS_IMBALANCE_NOTES.md
+++ b/results/mcolon/20251016/CLASS_IMBALANCE_NOTES.md
@@ -1,0 +1,19 @@
+# Class imbalance handling notes (2025 results)
+
+## Where this was evaluated
+- `results/mcolon/20251014/class_imbalance_method_comparison.py` explicitly compares baseline vs class-imbalance strategies (including `class_weight='balanced'`).
+
+## Current default behavior in the 2025 refactor
+- `predictive_signal_test(..., use_class_weights: bool = True)` defaults to using class weights.
+- When enabled, it sets `class_weight = 'balanced'` and passes that into `LogisticRegression`.
+- `run_analysis.py` wires this through `use_class_weights=config.USE_CLASS_WEIGHTS`.
+- `config.py` sets `USE_CLASS_WEIGHTS = True` by default.
+
+## Source tutorial / routed implementation status
+- In `src/analyze/difference_detection/classification_test_multiclass.py`, the routed API `run_classification_test()` delegates to `run_multiclass_classification_test()`.
+- The underlying classifier factory (`_make_logistic_classifier`) applies `class_weight='balanced'` for both binary and multiclass logistic regression.
+- With `verbose=True`, the implementation now logs the balancing policy and per-bin class counts (so balanced-weight assumptions are explicit during runs).
+
+## Important historical caveat
+- In the older 20251014 `robust_phenotype_emergence_classifaction.py`, `use_class_weights` existed in the signature/docstring, but the model instantiation shown there did not apply `class_weight`.
+- The 20251016 `classification/predictive_test.py` includes an explicit "FIXED" comment indicating the parameter is now actually used.

--- a/src/analyze/difference_detection/classification_test.py
+++ b/src/analyze/difference_detection/classification_test.py
@@ -289,6 +289,7 @@ def run_binary_classification_test(
 
     if verbose:
         print(f"Comparing {group1} (n={n_group1}) vs {group2} (n={n_group2})")
+        print("Classification weighting: class_weight='balanced' (enabled by default)")
 
     # Determine feature columns
     if isinstance(features, str):
@@ -415,6 +416,12 @@ def _run_classification(
 
         n_positive = int(np.sum(y_labels == positive_label))
         n_negative = int(np.sum(y_labels == negative_label))
+
+        if verbose:
+            print(
+                f"    Class counts (positive={positive_label}: {n_positive}, "
+                f"negative={negative_label}: {n_negative}); using balanced class weights"
+            )
 
         # Check class count (must contain both positive and negative labels)
         if n_positive == 0 or n_negative == 0:

--- a/src/analyze/difference_detection/classification_test_multiclass.py
+++ b/src/analyze/difference_detection/classification_test_multiclass.py
@@ -388,6 +388,7 @@ def run_multiclass_classification_test(
 
     if verbose:
         print(f"Multiclass comparison with {n_classes} classes: {class_labels}")
+        print("Classification weighting: class_weight='balanced' (enabled by default)")
 
     # Build embryo_id -> class_label mapping
     embryo_to_class = {}
@@ -553,6 +554,9 @@ def _run_multiclass_classification(
 
         # Check class counts
         class_counts = {label: np.sum(y_labels == label) for label in class_labels}
+        if verbose:
+            print(f"    Class counts: {class_counts}")
+            print("    Using balanced class weights for this bin")
         present_classes = [label for label, count in class_counts.items() if count > 0]
         missing_classes = [label for label, count in class_counts.items() if count == 0]
 
@@ -1052,6 +1056,7 @@ def run_classification_test(
         print(f"Groupby column: {groupby}")
         print(f"Groups: {groups}")
         print(f"Reference: {reference}")
+        print("Classifier policy: class_weight='balanced' for all logistic models")
     
     # Resolve comparisons
     comparison_specs = _resolve_comparison_groups(

--- a/src/analyze/difference_detection/docs/multiclass_classification_api.md
+++ b/src/analyze/difference_detection/docs/multiclass_classification_api.md
@@ -4,6 +4,11 @@ This document shows how to use the new Scanpy-style comparison API with visualiz
 
 ## Basic Usage
 
+> **Class imbalance default:** the routed `run_classification_test()` path uses logistic regression with `class_weight='balanced'` for both binary and multiclass runs.
+>
+> **Verbose logging:** with `verbose=True` (default), the run now prints the balancing policy and per-bin class counts so balancing assumptions are explicit in logs.
+
+
 ```python
 from analyze.difference_detection import run_classification_test
 

--- a/src/analyze/difference_detection/tests/test_class_weight_logging.py
+++ b/src/analyze/difference_detection/tests/test_class_weight_logging.py
@@ -1,0 +1,69 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import pandas as pd
+
+from analyze.difference_detection.classification_test_multiclass import (
+    _make_logistic_classifier,
+    run_classification_test,
+)
+
+
+class ClassWeightPolicyTests(unittest.TestCase):
+    def test_make_logistic_classifier_uses_balanced_weights(self):
+        clf_binary = _make_logistic_classifier(n_classes=2, random_state=42)
+        clf_multi = _make_logistic_classifier(n_classes=3, random_state=42)
+
+        self.assertEqual(clf_binary.class_weight, "balanced")
+        self.assertEqual(clf_multi.class_weight, "balanced")
+
+    def test_run_classification_test_verbose_reports_balanced_policy(self):
+        df = pd.DataFrame(
+            {
+                "embryo_id": ["e1", "e2", "e3", "e4"],
+                "cluster": ["A", "A", "WT", "WT"],
+                "predicted_stage_hpf": [10.0, 10.5, 10.2, 10.7],
+                "z_mu_b_0": [0.1, 0.2, -0.1, -0.2],
+            }
+        )
+
+        fake_result = {
+            "ovr_classification": {
+                "A": pd.DataFrame(
+                    [
+                        {
+                            "time_bin": 8,
+                            "time_bin_center": 10.0,
+                            "auroc_observed": 0.75,
+                            "pval": 0.05,
+                        }
+                    ]
+                )
+            }
+        }
+
+        with patch(
+            "analyze.difference_detection.classification_test_multiclass.run_multiclass_classification_test",
+            return_value=fake_result,
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                run_classification_test(
+                    df=df,
+                    groupby="cluster",
+                    groups=["A"],
+                    reference="WT",
+                    features=["z_mu_b_0"],
+                    n_permutations=0,
+                    verbose=True,
+                )
+
+            output = buf.getvalue()
+
+        self.assertIn("Classifier policy: class_weight='balanced'", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Reconcile conflicting changes between the ROI-discovery feature branch and `main` so the PR becomes mergeable while preserving the feature-branch ROI backend implementation.
- Incorporate recent `main` updates that standardize class-imbalance handling and explicit logging of `class_weight='balanced'` across binary and multiclass classification flows.
- Add a small test and documentation updates to assert and document the class-weighting policy for downstream CI and reviewers.

### Description
- Reconciled add/add conflicts in `results/mcolon/20260215_roi_discovery_via_ot_feature_maps/*` by keeping the ROI backend (feature-branch) implementations and aligning headers/README entries with the branch plan; several ROI modules (README, `roi_api.py`, `roi_config.py`, `roi_loader.py`, `roi_nulls.py`, `roi_sweep.py`, `roi_trainer.py`) were updated to the resolved versions.
- Updated difference-detection classification code to make class balancing explicit and to log balancing policy and per-bin class counts in `src/analyze/difference_detection/classification_test.py` and `src/analyze/difference_detection/classification_test_multiclass.py`.
- Added documentation note `results/mcolon/20251016/CLASS_IMBALANCE_NOTES.md` describing where class-weight behavior was evaluated and the current default behavior.
- Added a unit test `src/analyze/difference_detection/tests/test_class_weight_logging.py` that validates `_make_logistic_classifier` uses `class_weight='balanced'` and that the routed `run_classification_test()` prints the balancing policy when `verbose=True`.
- Minor refactor in the ROI trainer (`roi_trainer.py`) around `TrainResult` fields and relocation/clarification of `compute_logits` implementation and function export ordering.

### Testing
- Ran `git diff --check --cached` to verify there are no staged conflict markers or whitespace issues, and it completed successfully.
- Attempted interpreter sanity check `"$PYTHON" -c 'import sys; print(sys.executable)'`, which failed in this environment due to the referenced interpreter path not being present.
- Push to the remote from this environment failed due to missing GitHub credentials, so the resolved branch has not been published from this container; the new unit test file is present and intended to be executed by CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c906e574833284cde38934bdebec)