### PR TITLE
WIP: initial test plan and Phase 1 test file scaffolding for ROI discovery

### DIFF
--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PHASE0_SPEC.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PHASE0_SPEC.md
@@ -1,0 +1,290 @@
+# PHASE 0 SPEC (MorphSeq) — WT-Referenced OT + Rostral–Caudal (S) Bins
+
+Pilot genotype: cep290 (curvature phenotype)
+Primary goal: prove (1) OT mapping + QC is trustworthy and (2) discriminative signal localizes along S.
+Secondary goal: show directionality (displacement dynamics) can improve AUROC beyond scalar cost.
+
+## Core principles (locked)
+
+- One fixed source: pre-selected WT reference mask (template on 512×512 canonical grid).
+- Many targets: WT and cep290 embryos from ONE 2 hpf window (single window only for Phase 0).
+- Stability first: filtering + visual QC must pass before interpreting any classifier.
+- Statistics use UNSMOOTHED features. Smoothing is visualization-only.
+- CV and resampling are embryo-level (group by embryo_id).
+- Class imbalance handled using existing MorphSeq "balance method" used by prior classifiers (do not re-invent).
+
+## 0) ARTIFACTS + DATA CONTRACT (before any modeling)
+
+### 0.1 FeatureDataset (single source of truth; streamable on disk)
+
+Location:
+```
+results/<date>/roi_feature_dataset_phase0_<tag>/
+```
+
+Files:
+```
+manifest.json
+metadata.parquet
+features.zarr/
+  X/             (N, 512, 512, C) float32   # per-sample OT-derived feature maps
+  y/             (N,) int {0,1}
+  mask_ref/      (512,512) bool/uint8
+  qc/
+    total_cost_C/    (N,) float32
+    outlier_flag/    (N,) bool
+  optional/
+    S_map_ref/       (512,512) float32 in [0,1]   # rostral→caudal coordinate map in template space
+    tangent_ref/     (512,512,2) float32 (optional) # local unit tangent e_parallel at each pixel
+    normal_ref/      (512,512,2) float32 (optional) # local unit normal e_perp at each pixel
+```
+
+### manifest.json must declare (hard validation)
+
+- canonical_grid: 512×512
+- stage_window: one 2 hpf bin (explicit start/end)
+- channel_schema (C channels) with exact definitions
+- OT_params_hash + OT solver version
+- reference_mask_id
+- QC rules: IQR multiplier=1.5 on total_cost_C; logging requirements
+- split_policy: group_key=embryo_id
+- class_balance_strategy: "morphseq_balance_method" (existing utility; fold-local weights preferred)
+- smoothing_policy: "visualization-only; stats computed on unsmoothed features"
+- S orientation: S=0 head, S=1 tail
+
+### metadata.parquet required columns
+
+- sample_id, embryo_id, snip_id
+- label_int (0 WT, 1 cep290), label_str
+- stage/timepoint fields (explicit)
+- total_cost_C, qc_outlier_flag
+- provenance tags (batch/experiment/session)
+
+## 1) BUILD OT MAPS (source fixed, targets many)
+
+### 1.1 Inputs
+
+- mask_ref (template WT mask)
+- per-sample aligned mask_target on canonical grid (WT + cep290)
+
+### 1.2 OT mapping exports per sample (template space)
+
+For each sample i, run unbalanced OT (fixed params) ref → target, export:
+- cost_density c_i(x,y)        (scalar map)
+- displacement field d_i(x,y)  = (u,v) (vector map)
+- delta_mass Δm_i(x,y)         (scalar map; unbalanced OT)
+- total_cost_C_i               (scalar)
+
+Store at least these channels in X (Phase 0 base):
+```
+Channel set v0 (minimum):
+  C=1: cost_density
+
+Channel set v1 (add dynamics; after v0 stable):
+  + disp_u, disp_v
+  + disp_mag = sqrt(u^2+v^2)
+  + delta_mass
+
+Optional derived (later):
+  + divergence (finite diff of d in template grid)
+```
+
+## 2) QC + OUTLIER FILTERING (must run before classification)
+
+### 2.1 Primary filter (locked)
+
+- Compute total_cost_C_i for all samples.
+- IQR filter (1.5×IQR): flag outliers.
+- Do NOT delete; store qc_outlier_flag and a dropped_samples table.
+
+### 2.2 QC deliverables (required figures; these are "gates")
+
+- QC-1: histogram/violin of total_cost_C (before/after filtering)
+- QC-2: montage (or grid) of top-N highest-cost samples with their cost maps
+- QC-3: summary table of dropped samples (embryo_id, snip_id, C, reason)
+
+Gate to proceed:
+- Post-filter mean maps are not dominated by obvious alignment failures.
+
+## 3) VISUALIZATIONS (Phase 0's main debugging instrument)
+
+All visual smoothing is for display only.
+
+### 3.1 Cost density maps (template space)
+
+- Fig A1: mean cost density (WT)
+- Fig A2: mean cost density (cep290)
+- Fig A3: difference (cep290 − WT)
+- Fig A4/A5/A6: filled-contour versions with Gaussian smoothing (sigma grid: e.g. 1, 2, 4)
+
+Preferred clean style (for all scalar maps):
+- embryo outline (mask_ref boundary)
+- filled contours (smoothed scalar field)
+- thin contour lines on top (same levels)
+- consistent color scale across WT/mutant/diff
+
+### 3.2 Displacement dynamics maps (template space)
+
+- Fig B1: mean displacement vector field (WT) (quiver downsampled)
+- Fig B2: mean displacement vector field (cep290)
+- Fig B3: difference vector field (cep290 − WT)
+
+Optional:
+- scalar map of mean displacement magnitude (|d|) with same contour style
+
+## 4) DEFINE S COORDINATE + BIN INTO K SEGMENTS
+
+### 4.1 Compute S_map_ref once (template coordinate map)
+
+- Fit reference spline/centerline on the WT template.
+- Produce S_map_ref(x,y) in [0,1] for pixels in mask_ref.
+- Orientation convention fixed: S=0 head, S=1 tail.
+- Store S_map_ref in features.zarr/optional.
+
+### 4.2 Precompute local basis in template (enables direction features)
+
+- e_parallel(x,y): unit tangent direction at S(x,y)
+- e_perp(x,y): unit normal
+- Store as tangent_ref/normal_ref (optional but recommended once directionality is enabled).
+
+### 4.3 Bin definition
+
+- Choose K=10 initially (also run K=20 as robustness check).
+- Bin k: S ∈ [k/K, (k+1)/K)
+
+## 5) BUILD THE S-BIN FEATURE TABLE (models consume this, not images)
+
+Output table (tiny; fast; reusable):
+```
+results/<date>/roi_feature_dataset_phase0_<tag>/features_sbins.parquet
+```
+
+Rows: N×K (sample-by-bin)
+
+Columns (minimum v0):
+- sample_id, embryo_id, snip_id, label_int, stage_window, qc_outlier_flag
+- k_bin, S_lo, S_hi
+- cost_mean
+
+Add dynamics v1 (after v0 stable):
+- disp_mag_mean
+- disp_par_mean = mean(d · e_parallel)
+- disp_perp_mean = mean(d · e_perp)
+
+Optional later:
+- delta_mass_mean
+- divergence_mean
+
+Important:
+- These per-bin summaries are computed on UNSMOOTHED maps.
+- Smoothing may be applied to plotted curves only.
+
+## 6) CLASSIFICATION + AUROC LOCALIZATION (the "signal exists here" proof)
+
+All analyses run:
+- (A) with all samples
+- (B) with qc_outlier_flag excluded
+
+Report both to demonstrate filtering impact.
+
+### 6.1 Univariate AUROC per bin (fast, interpretable; required)
+
+For each bin k:
+- AUROC_k(cost_mean)
+- AUROC_k(disp_mag_mean) (once v1 enabled)
+- AUROC_k(disp_par_mean), AUROC_k(disp_perp_mean) (once v1 enabled)
+
+Deliverables:
+- Plot: AUROC vs S-bin (one curve per feature)
+- Optional display smoothing of AUROC curve (visualization only)
+
+### 6.2 Multivariate logistic regression across bins (still simple; required)
+
+Model:
+- Input vector for each sample: X_i = [feature(i,0), ..., feature(i,K-1)]
+- CV: grouped by embryo_id
+- Class imbalance: use MorphSeq balance method (existing utility)
+
+Outputs:
+- overall CV AUROC
+- coefficient profile over bins (interpretability)
+- compare models:
+  - cost-only
+  - dynamics-only (disp features)
+  - cost + dynamics (expected best)
+
+### 6.3 Directionality-as-2D feature per bin (optional but valuable once v1 works)
+
+Per bin k, define 2D vector feature:
+- v_i,k = (disp_par_mean, disp_perp_mean)
+- Train tiny logistic regression for each bin k separately with embryo-level CV, report AUROC_k(dir).
+
+## 7) 1D PATCH (INTERVAL) SEARCH ON S (automated localization)
+
+Goal: find contiguous region I=[a..b] that best discriminates.
+
+### Procedure (required)
+
+For each interval I:
+- define an interval feature:
+  - simplest: mean over bins in I (per feature)
+  - or concatenate bins in I (still small)
+- score via grouped-CV AUROC (embryo_id)
+
+Deterministic selection rule (locked and logged):
+- Option A (recommended): smallest interval within ε of best AUROC
+- Option B: add length penalty gamma and maximize AUROC - gamma×(len/K)
+
+Sanity checks (required):
+- Only-interval: keep bins in I → AUROC should stay high
+- Drop-interval: zero bins in I → AUROC should drop
+
+Deliverables:
+- Plot: best AUROC vs interval length
+- Plot: selected interval highlighted on S axis
+- Table: top-10 intervals + scores
+
+## 8) NULLS + STABILITY (selection-aware; required)
+
+### 8.1 Permutation null (embryo-level; selection-aware)
+
+- Permute labels at embryo_id unit.
+- Repeat the SAME selection procedure:
+  - if reporting max AUROC_k: record max under permutation
+  - if reporting best interval: record best-interval AUROC under permutation
+- p-value computed against selected statistic (no leakage / no "fixed lambda" trap).
+
+### 8.2 Bootstrap stability
+
+- Bootstrap embryos within class.
+- Recompute:
+  - AUROC_k curves (confidence bands)
+  - selected interval endpoints distribution
+  - interval overlap stability metric
+
+## 9) PHASE 0 "DONE" CRITERIA (gates to Phase 1 2D ROI)
+
+Phase 0 is done when:
+- Visual QC plots show coherent WT vs mutant differences post-filtering.
+- AUROC_k has stable peaks (not flat noise) and is robust under bootstrap.
+- Best interval is stable (endpoints don't wander wildly) and sanity checks behave as expected.
+- Adding dynamics (disp-based features) provides equal or improved AUROC vs cost-only, and the directionality plots look biologically sensible (not boundary artifacts).
+
+### Note on future extensibility (mention only, not implement now)
+
+- Regionizer abstraction:
+  - today: uniform S bins (K segments)
+  - future: anatomical parcels (head/trunk/tail/yolk/etc.) as drop-in replacements
+- The same downstream pipeline applies: per-region summaries → AUROC → patch search → nulls.
+
+## Implementation order (Phase 0)
+
+0. Build FeatureDataset contract + validator (manifest + zarr + parquet)
+1. Generate OT maps (cost + displacement) and qc scalars; write FeatureDataset
+2. Run QC plots + IQR filtering report (must look sane)
+3. Compute S_map_ref (+ tangent/normal if enabling directionality)
+4. Build features_sbins.parquet (cost-only first)
+5. Run AUROC_k (cost) + grouped-CV logistic (cost)
+6. Enable dynamics features (disp_mag, disp_par, disp_perp) and rerun models
+7. Run interval search + sanity checks
+8. Run permutation null + bootstrap stability (selection-aware)

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PLAN.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/PLAN.md
@@ -1,6 +1,6 @@
 # Implementation Plan (MorphSeq) — ROI Discovery via WT-Referenced OT Feature Maps
 
-**(Updated: Phase 1 commits to FIXED (λ,μ) bootstrap; removes compare(); clarifies "computationally stable" vs "biology-dependent" tuning)**
+**(Updated: Phase 0 → Phase 1 → Phase 2.0 → Phase 2.5 ordering with success criteria)**
 
 ## Purpose
 
@@ -18,31 +18,110 @@
 - Fong et al. 2019 "Extremal Perturbations":
   https://arxiv.org/abs/1910.08485
 
-## Core Model (Linear, small-sample friendly; ROI from weights)
+---
 
-- Weight-map regularized logistic regression:
+## Phase Ordering
 
-      J(w,b) = logistic_loss(y, <w, X> + b) + λ||w||_1 + μ TV(w)
-
-- ROI derived from |w| after training (quantile threshold default).
-- TV neighborhood: 4-neighborhood restricted to valid in-mask edges (no padding outside embryo).
-
-## Scaling Pattern (default)
-
-- Learn w_low at low resolution; upsample inside the model:
-  - learn_res=128 (default), optional 256 later
-  - output_res=512 always (canonical)
-  - penalties (L1, TV) applied in low-res space
+| Phase | Name | Goal | Modules |
+|-------|------|------|---------|
+| **0** | 1D S-bin localization | Fast sanity check: do OT features separate WT/cep290 along the body axis? | `p0_*.py`, `run_phase0.py` |
+| **1** | 2D weight-map ROI | Full spatial ROI via L1+TV regularized logistic regression | `roi_trainer.py`, `roi_sweep.py`, `roi_nulls.py`, `roi_api.py` |
+| **2.0** | Occlusion validation | Causal check: does masking/preserving the ROI change classification? | `roi_occlusion.py`, `roi_perturbation.py`, `roi_resampling.py` |
+| **2.5** | Mask learning | Learn soft ROI mask directly from perturbation objective | `roi_mask_param.py`, `roi_mask_trainer.py`, `roi_mask_objective.py` |
 
 ---
 
-## A) DATA CONTRACT (finalize before model code)
+## PHASE 0: 1D S-bin Localization (WT-referenced OT)
 
-### FeatureDataset = standardized on-disk source of truth
+### Purpose
+
+Before investing in 2D weight-map optimization, answer:
+> "Do OT-derived features (cost, displacement, mass) discriminate WT from cep290,
+> and if so, WHERE along the rostral-caudal axis?"
+
+### Pipeline Steps
+
+| Step | Module | Gate |
+|------|--------|------|
+| 0.1 OT map generation | `p0_ot_maps.py` | Maps generated for all samples |
+| 0.2 QC + filtering | `p0_qc.py` | Visual check: mean maps not dominated by alignment failures |
+| 0.3 S coordinate | `p0_s_coordinate.py` | S_map covers >95% of mask pixels |
+| 0.4 S-bin features | `p0_sbin_features.py` | features_sbins.parquet written |
+| 0.5 AUROC localization | `p0_classification.py` | At least one bin has AUROC > 0.65 |
+| 0.6 Dynamics (V1) | `p0_sbin_features.py` + `p0_classification.py` | Compare cost-only vs dynamics models |
+| 0.7 Interval search | `p0_interval_search.py` | Selected interval passes sanity checks |
+| 0.8 Nulls + stability | `p0_nulls.py` | Permutation p < 0.05, bootstrap interval endpoints stable |
+
+### Data Contract (Phase 0 Extension)
+
+Phase 0 FeatureDataset adds to the base contract:
+- `features.zarr/optional/S_map_ref` — (512,512) float32, S ∈ [0,1]
+- `features.zarr/optional/tangent_ref` — (512,512,2) float32
+- `features.zarr/optional/normal_ref` — (512,512,2) float32
+- `manifest.json` adds: `phase`, `stage_window`, `OT_params_hash`, `S_orientation`
+
+### Channel Sets
+
+| Set | Channels | C |
+|-----|----------|---|
+| `V0_COST` | cost_density | 1 |
+| `V1_DYNAMICS` | cost_density, disp_u, disp_v, disp_mag, delta_mass | 5 |
+
+### S-Bin Features (per sample per bin)
+
+| Feature | V0 | V1 | Definition |
+|---------|----|----|------------|
+| cost_mean | x | x | mean cost_density in bin |
+| disp_mag_mean | | x | mean displacement magnitude |
+| disp_par_mean | | x | mean displacement · e_parallel |
+| disp_perp_mean | | x | mean displacement · e_perp |
+
+### Interval Selection Rules
+
+- **Parsimony (default):** smallest interval within ε of best AUROC
+- **Penalized:** maximize AUROC − γ·(len/K)
+
+### Null Tests (selection-aware)
+
+1. **Permutation null (max AUROC_k):** embryo-level label permutation, record max AUROC across bins
+2. **Permutation null (best interval):** full interval search under permuted labels
+3. **Bootstrap stability:** embryo-level within-class resampling → AUROC CI bands + interval endpoint distributions
+
+### Visualization Deliverables
+
+| Figure | What it shows |
+|--------|---------------|
+| A1–A3 | Mean cost density: WT, cep290, difference |
+| A4+ | Smoothed contour versions at σ=1,2,4 |
+| B1–B3 | Mean displacement quiver fields (V1 only) |
+| C1 | S coordinate map on reference |
+| D1 | AUROC vs S-bin (per feature) with bootstrap CI |
+| D2 | Logistic coefficient profile |
+| E1 | Interval search results |
+| F1–F2 | Permutation null histograms |
+| F3 | Bootstrap interval stability |
+
+### Success Criteria (Phase 0)
+
+- [ ] OT maps generated for all samples without errors
+- [ ] QC gate passed: mean maps are biologically plausible, not alignment artifacts
+- [ ] At least one S-bin achieves AUROC > 0.65 (cost channel)
+- [ ] Selected interval passes only-interval / drop-interval sanity checks
+- [ ] Permutation p-value < 0.05 for max AUROC_k
+- [ ] Bootstrap interval endpoints have std < 2 bins
+- [ ] All visualization deliverables generated
+
+---
+
+## PHASE 1: 2D Weight-Map ROI (sections A–G from original plan)
+
+### A) DATA CONTRACT (finalize before model code)
+
+#### FeatureDataset = standardized on-disk source of truth
 
 **Format:** Zarr (arrays) + Parquet (metadata) + JSON manifest (provenance + rules)
 
-### Directory
+#### Directory
 
     results/<date>/roi_feature_dataset_<tag>/
       manifest.json
@@ -55,180 +134,169 @@
           total_cost_C/    (N,) float32
           outlier_flag/    (N,) bool
 
-### Manifest (must include; hard validation)
+#### Manifest (must include; hard validation)
 
 - canonical_grid: 512×512
 - channel_schema: names + definitions + units
-- QC rules:
-  - IQR outlier filter on total_cost_C (1.5×IQR), logged, never deleted
-- split_policy:
-  - group_key = embryo_id (MANDATORY; prevents leakage)
-- class_balance_strategy (MANDATORY; declared here):
-  - use existing MorphSeq "balance method" already used in prior classification models
-  - weights computed from TRAIN fold only (recommended)
+- QC rules: IQR outlier filter on total_cost_C (1.5×IQR), logged, never deleted
+- split_policy: group_key = embryo_id (MANDATORY; prevents leakage)
+- class_balance_strategy (MANDATORY): sklearn balanced class_weight, TRAIN fold only
 - chunking/compression spec for X
 
----
+### B) DATA INGESTION (streamable + deterministic)
 
-## B) DATA INGESTION (streamable + deterministic)
-
-- Chunk X along N; keep 512×512 tiles contiguous:
-  chunk (8,512,512,C) or (16,512,512,C)
+- Chunk X along N; keep 512×512 tiles contiguous: chunk (8,512,512,C) or (16,512,512,C)
 - Loader supports full-batch (small N) and minibatch (large N).
-- Filtering is deterministic via qc/outlier_flag (default exclude; never drop silently).
-- CV splits grouped by embryo_id; fold-local class weights (from training fold only).
+- Filtering is deterministic via qc/outlier_flag.
+- CV splits grouped by embryo_id; fold-local class weights.
 
----
+### C) TV DEFINITION (explicit boundary behavior)
 
-## C) TV DEFINITION (explicit boundary behavior)
-
-- TV defined over edges; include edge (p,q) only if p and q are inside mask_ref.
+- TV defined over edges; include edge (p,q) only if both inside mask_ref.
 - No zero-padding outside embryo.
-- Boundary pixels therefore have fewer valid neighbors ("reduced-degree boundary").
-- Diagnostics:
-  - report boundary_fraction of ROI (ROI overlap with thin boundary band) to detect registration-driven edge artifacts.
-- Optional later: TV normalization by edge count if mask geometry varies across datasets; not required in Phase 1.
+- Boundary pixels have fewer valid neighbors ("reduced-degree boundary").
+- Diagnostics: boundary_fraction of ROI.
 
----
-
-## D) MODEL TRAINING (JAX backend)
-
-### Requirements
+### D) MODEL TRAINING (JAX backend)
 
 - JAX + Optax; jit train_step
-- objective logs must include raw + weighted components:
-  - logistic_loss_raw
-  - l1_raw, tv_raw
-  - l1_weighted=λ*l1_raw, tv_weighted=μ*tv_raw
-  - total_objective
-  - class_weights used
-
-### Default training mode
-
 - params: w_low (learn_res×learn_res×C), b
 - w_full = bilinear_upsample(w_low → 512×512×C)
 - logits: <X, w_full> + b
 - loss: class-weighted logistic + λL1(w_low) + μTV(w_low)
+- Objective logs: logistic_loss_raw, l1_raw, tv_raw, l1_weighted, tv_weighted, total_objective
 
----
+### E) λ/μ SWEEP + DETERMINISTIC SELECTION
 
-## E) λ/μ SWEEP + DETERMINISTIC SELECTION
+- Coarse λ×μ grid
+- Selection: Pareto knee (recommended) or ε-best
+- Complexity metrics: area_fraction, n_components, boundary_fraction
+- Store full sweep table + selection metadata
 
-### Important nuance (explicit)
+### F) NULLS + STABILITY
 
-- There is no universal "perfect (λ,μ)".
-- (λ,μ) depends on:
-  - phenotype type + expected spatial scale
-  - signal-to-noise and sample size
-  - feature channel choice (cost vs displacement vs div vs Δm)
-- Therefore we treat sweeps as discovery + documentation, not one-time "solve and forget".
+- **NULL 1:** embryo-level label permutation (selection-aware)
+- **NULL 3:** bootstrap stability at FIXED (λ,μ)
+- Bootstrap: resample embryos, fit at fixed params, measure IoU
 
-### Phase 1: minimal sweep for a stable starting point
-
-- Coarse λ×μ grid (small) to identify a sensible region of operation.
-- Deterministic selection rule (pick one and log):
-  - **Option A (recommended):** knee on Pareto front (AUROC vs complexity)
-  - **Option B:** smallest complexity within ε of best AUROC
-
-### Complexity metrics (recorded for selection + reporting)
-
-- area_fraction, n_components, boundary_fraction
-
-### Outputs
-
-- Store the full sweep table and the selected (λ,μ) with selection score and rule parameters (beta/ε).
-- These become "notes" for future biology-specific runs.
-
----
-
-## F) NULLS + STABILITY (Phase 1 commitment)
-
-### NULL 1 (required): label permutation significance (selection-aware)
-
-- Permute labels at embryo_id unit.
-- For each permuted run:
-  - run the same sweep + same deterministic selection rule
-  - record selected AUROC (and optionally max across sweep)
-- p-value computed against the selection-aware null.
-
-### NULL 3 (required): bootstrap stability at FIXED (λ,μ)
-
-**Phase 1 commitment:** bootstrap uses the selected (λ,μ) fixed.
-
-**Reason:**
-- answers the interpretable question "is THIS ROI stable?"
-- cheaper and more scalable than full-sweep bootstrap
-- supports quick iteration and easier debugging
-
-### Bootstrap protocol
-
-- Resample embryos with replacement within each class.
-- Fit model at fixed (λ,μ), same learn_res.
-- Extract ROI via fixed thresholding rule (quantile q) and compute:
-  - IoU distribution across bootstrap ROIs
-  - variability of ROI area/components/boundary_fraction
-- Report stability summary alongside AUROC and permutation p-value.
-
-### Deferred upgrade (Phase 2 / if needed)
-
-- full-sweep bootstrap ("is the selection procedure stable?") — optional later.
-
-### NULL 2 (spatial structured null)
-
-- Deprioritized; revisit only if reviewers demand.
-
----
-
-## G) BIOLOGIST-FACING FRONT END (scope-limited for Phase 1)
-
-### Phase 1 API (minimal; no compare())
+### G) BIOLOGIST-FACING FRONT END
 
 ```python
-morphseq.roi.fit(
-    genotype="cep290",
-    features="cost" | "cost+disp" | "all_ot",
-    learn_res=128|256,
-    roi_size="small|medium|large",      # maps to λ grid presets
-    smoothness="low|medium|high",       # maps to μ grid presets
-    class_balance="morphseq_balance_method",
-    null="permute|bootstrap|both|none",
-    n_permute=100, n_boot=200,
-    out_dir=...,
-)
-
-morphseq.roi.plot(run_id, style="filled_contours", overlays=["outline", "optional_S_isolines"])
-morphseq.roi.report(run_id)  # -> AUROC, selected (λ,μ), area/components, permutation p, bootstrap IoU, boundary_fraction
+morphseq.roi.fit(genotype="cep290", features="cost", ...)
+morphseq.roi.plot(run_id, style="filled_contours", overlays=["outline"])
+morphseq.roi.report(run_id)
 ```
 
-- Optional diagnostic overlay: S isolines (not required for core ROI training)
+### Success Criteria (Phase 1)
+
+- [ ] FeatureDataset validates (schema, shapes, QC arrays, split policy)
+- [ ] JAX trainer converges (objective decreasing, loss < initial)
+- [ ] Sweep produces non-trivial ROI (area_fraction > 0.01 and < 0.5)
+- [ ] Permutation p < 0.05
+- [ ] Bootstrap IoU > 0.5 (median)
+- [ ] boundary_fraction < 0.3 (no edge artifacts)
+- [ ] `roi.fit()`, `roi.plot()`, `roi.report()` run end-to-end
 
 ---
 
-## Immediate next actions (ready to build)
+## PHASE 2.0: Occlusion Validation
 
-1. **Build FeatureDataset builder + validator (contract-first)**
-   - Write Zarr/Parquet/manifest including QC rules, split policy, class_balance_strategy.
-   - Implement fail-fast schema checks with informative errors.
+### Purpose
 
-2. **Implement streaming loader**
-   - Deterministic filtering, embryo-grouped CV splits, fold-local class weights.
+Causal check: does masking/preserving the ROI change classification?
 
-3. **Implement JAX trainer (learn_res=128 default)**
-   - Weighted logistic + λL1 + μTV with explicit TV boundary rule.
-   - Store raw + weighted objective terms and class weights.
+### Protocol
 
-4. **Implement small λ×μ sweep + deterministic selection**
-   - Log Pareto set + knee/ε selection metadata.
-   - Export sweep table and selected (λ,μ).
+- **Delete perturbation:** X_perturbed = (1-mask)*X + mask*baseline
+- **Preserve perturbation:** X_perturbed = mask*X + (1-mask)*baseline
+- Baseline = WT spatial mean (computed from in-bag training samples only)
+- Bootstrap OOB evaluation: fit on in-bag, evaluate on OOB
 
-5. **Implement NULL 1 permutation (selection-aware) + NULL 3 bootstrap (fixed λ/μ)**
-   - Parallel, resume-safe artifacts.
-   - Report p-value and bootstrap IoU.
+### Metrics
 
-## Definition of "done" (Phase 1)
+- delete_gap = AUROC(original) − AUROC(delete_ROI)
+- preserve_gap = AUROC(preserve_ROI) − AUROC(random_preserve)
 
-- Validated, streamable FeatureDataset
-- Reproducible sweep with deterministic selection and documented (λ,μ) behavior
-- Selection-aware permutation p-value
-- Fixed-(λ,μ) bootstrap ROI stability (IoU + ROI complexity diagnostics)
-- Minimal front end that a non-coder can run and interpret
+### Success Criteria (Phase 2.0)
+
+- [ ] delete_gap > 0.05 (removing ROI hurts classification)
+- [ ] preserve_gap > 0.05 (ROI alone is sufficient)
+- [ ] Bootstrap CI for delete_gap does not include 0
+
+---
+
+## PHASE 2.5: Mask Learning
+
+### Purpose
+
+Learn a soft ROI mask directly by optimizing a perturbation objective:
+> "Find the smallest mask m such that preserving m·X keeps classification intact."
+
+### Model
+
+- Parameterize m via sigmoid of learnable low-res field
+- Dual objective: score(preserve_m) − score(delete_m)
+- Penalties: λ_area * ||m||_1 + μ_TV * TV(m) + entropy term
+- Anti-cheating: circular jittering during training
+
+### Success Criteria (Phase 2.5)
+
+- [ ] Learned mask has IoU > 0.3 with Phase 1 weight-map ROI
+- [ ] Learned mask is more compact (smaller area_fraction) than Phase 1 ROI
+- [ ] Delete gap with learned mask >= delete gap with Phase 1 ROI
+
+---
+
+## File Inventory
+
+### Phase 0 modules (NEW)
+
+| File | Purpose |
+|------|---------|
+| `roi_config.py` | Extended: Phase0RunConfig, Phase0FeatureSet, S-bin/interval/null configs |
+| `roi_feature_dataset.py` | Extended: Phase0FeatureDatasetBuilder with S_map_ref, basis vectors |
+| `p0_ot_maps.py` | OT map generation (fixed WT ref → all targets) |
+| `p0_qc.py` | QC suite: IQR filter, histograms, worst-sample montage, gate check |
+| `p0_s_coordinate.py` | S coordinate from centerline + local tangent/normal basis |
+| `p0_sbin_features.py` | S-bin feature table builder (v0: cost, v1: dynamics) |
+| `p0_classification.py` | AUROC per bin + grouped-CV logistic regression |
+| `p0_interval_search.py` | 1D contiguous interval search + sanity checks |
+| `p0_nulls.py` | Selection-aware permutation null + bootstrap stability |
+| `p0_viz.py` | Full Phase 0 visualization suite |
+| `run_phase0.py` | Phase 0 orchestrator |
+
+### Phase 1 modules (existing, complete)
+
+| File | Purpose |
+|------|---------|
+| `roi_trainer.py` | JAX trainer: L1+TV regularized logistic regression |
+| `roi_tv.py` | Total variation with mask-aware boundaries |
+| `roi_sweep.py` | λ/μ sweep + Pareto/ε selection |
+| `roi_nulls.py` | Label permutation + bootstrap stability |
+| `roi_loader.py` | Streaming loader with grouped CV splits |
+| `roi_api.py` | Biologist-facing API (fit/plot/report) |
+
+### Phase 2.0 modules (existing, complete)
+
+| File | Purpose |
+|------|---------|
+| `roi_occlusion.py` | Bootstrap occlusion validation |
+| `roi_perturbation.py` | Perturbation primitives + spatial baseline |
+| `roi_resampling.py` | Group-aware bootstrap resampling |
+
+### Phase 2.5 modules (existing, partial)
+
+| File | Purpose |
+|------|---------|
+| `roi_mask_param.py` | Mask parameterization (sigmoid, upsample, TV, jitter) |
+| `roi_mask_trainer.py` | Fixed-model mask learning trainer |
+| `roi_mask_objective.py` | Perturbation objectives (stub) |
+
+### Shared
+
+| File | Purpose |
+|------|---------|
+| `roi_config.py` | All configuration dataclasses |
+| `roi_feature_dataset.py` | FeatureDataset builder + validator |
+| `roi_viz.py` | Phase 1 visualization (weight maps, Pareto, nulls) |
+| `run_roi_discovery.py` | Example driver script |

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_classification.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_classification.py
@@ -1,0 +1,235 @@
+"""
+Phase 0 Step 6: Classification + AUROC Localization.
+
+Provides:
+  6.1 Univariate AUROC per bin (fast, interpretable)
+  6.2 Multivariate logistic regression across bins (grouped CV)
+
+All CV uses embryo-level grouping (GroupKFold by embryo_id).
+Class imbalance handled via sklearn class_weight='balanced'.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import GroupKFold
+from sklearn.utils.class_weight import compute_class_weight
+
+logger = logging.getLogger(__name__)
+
+
+def compute_auroc_per_bin(
+    sbin_df: pd.DataFrame,
+    feature_col: str = "cost_mean",
+    exclude_outliers: bool = True,
+) -> pd.DataFrame:
+    """
+    6.1: Univariate AUROC per S-bin.
+
+    For each bin k, compute AUROC of feature_col for discriminating label_int.
+
+    Returns DataFrame with columns: k_bin, S_lo, S_hi, auroc, n_samples.
+    """
+    if exclude_outliers:
+        df = sbin_df[~sbin_df["qc_outlier_flag"]].copy()
+    else:
+        df = sbin_df.copy()
+
+    results = []
+    for k_bin, group in df.groupby("k_bin"):
+        y = group["label_int"].values
+        x = group[feature_col].values
+
+        if len(np.unique(y)) < 2:
+            auroc = np.nan
+        elif np.std(x) < 1e-12:
+            auroc = 0.5
+        else:
+            auroc = roc_auc_score(y, x)
+
+        results.append({
+            "k_bin": k_bin,
+            "S_lo": group["S_lo"].iloc[0],
+            "S_hi": group["S_hi"].iloc[0],
+            "feature": feature_col,
+            "auroc": auroc,
+            "n_samples": len(group),
+        })
+
+    return pd.DataFrame(results)
+
+
+def compute_auroc_all_features(
+    sbin_df: pd.DataFrame,
+    feature_cols: List[str],
+    exclude_outliers: bool = True,
+) -> pd.DataFrame:
+    """Compute AUROC per bin for multiple features, return concatenated DataFrame."""
+    dfs = []
+    for col in feature_cols:
+        if col in sbin_df.columns:
+            df = compute_auroc_per_bin(sbin_df, feature_col=col, exclude_outliers=exclude_outliers)
+            dfs.append(df)
+    return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+
+
+def _pivot_sbin_to_sample_features(
+    sbin_df: pd.DataFrame,
+    feature_cols: List[str],
+    exclude_outliers: bool = True,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Pivot S-bin table to per-sample feature matrix.
+
+    Returns (X, y, groups) where X has shape (N_samples, K * len(feature_cols)).
+    """
+    if exclude_outliers:
+        df = sbin_df[~sbin_df["qc_outlier_flag"]].copy()
+    else:
+        df = sbin_df.copy()
+
+    K = df["k_bin"].nunique()
+    sample_ids = df["sample_id"].unique()
+    N = len(sample_ids)
+
+    X = np.zeros((N, K * len(feature_cols)), dtype=np.float64)
+    y = np.zeros(N, dtype=int)
+    groups = []
+
+    for i, sid in enumerate(sample_ids):
+        sample_rows = df[df["sample_id"] == sid].sort_values("k_bin")
+        y[i] = sample_rows["label_int"].iloc[0]
+        groups.append(sample_rows["embryo_id"].iloc[0])
+
+        for j, col in enumerate(feature_cols):
+            vals = sample_rows[col].values
+            X[i, j * K:(j + 1) * K] = vals
+
+    return X, y, np.array(groups)
+
+
+def run_grouped_cv_logistic(
+    sbin_df: pd.DataFrame,
+    feature_cols: List[str],
+    n_folds: int = 5,
+    exclude_outliers: bool = True,
+) -> Dict:
+    """
+    6.2: Multivariate logistic regression across bins with grouped CV.
+
+    Returns dict with:
+      - auroc_mean, auroc_std, auroc_folds
+      - coef_mean: mean coefficient profile over bins
+      - model_label: description of features used
+    """
+    X, y, groups = _pivot_sbin_to_sample_features(
+        sbin_df, feature_cols, exclude_outliers=exclude_outliers,
+    )
+
+    n_unique_groups = len(np.unique(groups))
+    actual_folds = min(n_folds, n_unique_groups)
+    if actual_folds < 2:
+        logger.warning(f"Only {n_unique_groups} unique groups, cannot run CV")
+        return {"auroc_mean": np.nan, "auroc_std": np.nan, "auroc_folds": [],
+                "coef_mean": np.zeros(X.shape[1]), "model_label": "+".join(feature_cols)}
+
+    gkf = GroupKFold(n_splits=actual_folds)
+    aurocs = []
+    coefs = []
+
+    for train_idx, val_idx in gkf.split(X, y, groups):
+        X_train, y_train = X[train_idx], y[train_idx]
+        X_val, y_val = X[val_idx], y[val_idx]
+
+        if len(np.unique(y_train)) < 2 or len(np.unique(y_val)) < 2:
+            continue
+
+        clf = LogisticRegression(
+            class_weight="balanced",
+            max_iter=1000,
+            solver="lbfgs",
+            random_state=42,
+        )
+        clf.fit(X_train, y_train)
+
+        y_prob = clf.predict_proba(X_val)[:, 1]
+        aurocs.append(roc_auc_score(y_val, y_prob))
+        coefs.append(clf.coef_[0])
+
+    result = {
+        "auroc_mean": float(np.mean(aurocs)) if aurocs else np.nan,
+        "auroc_std": float(np.std(aurocs)) if aurocs else np.nan,
+        "auroc_folds": aurocs,
+        "coef_mean": np.mean(coefs, axis=0) if coefs else np.zeros(X.shape[1]),
+        "model_label": "+".join(feature_cols),
+        "n_folds_completed": len(aurocs),
+    }
+
+    logger.info(
+        f"Logistic CV ({result['model_label']}): "
+        f"AUROC={result['auroc_mean']:.4f}±{result['auroc_std']:.4f} "
+        f"({result['n_folds_completed']} folds)"
+    )
+    return result
+
+
+def run_phase0_classification(
+    sbin_df: pd.DataFrame,
+    n_folds: int = 5,
+) -> Dict:
+    """
+    Run full Phase 0 classification suite.
+
+    Runs with/without outliers for comparison, and compares:
+      - cost-only
+      - dynamics-only (if available)
+      - cost + dynamics (if available)
+    """
+    has_dynamics = "disp_mag_mean" in sbin_df.columns
+
+    results = {}
+
+    for label_suffix, exclude in [("filtered", True), ("all", False)]:
+        # AUROC per bin
+        auroc_cost = compute_auroc_per_bin(sbin_df, "cost_mean", exclude_outliers=exclude)
+        results[f"auroc_per_bin_cost_{label_suffix}"] = auroc_cost
+
+        if has_dynamics:
+            for feat in ["disp_mag_mean", "disp_par_mean", "disp_perp_mean"]:
+                if feat in sbin_df.columns:
+                    results[f"auroc_per_bin_{feat}_{label_suffix}"] = compute_auroc_per_bin(
+                        sbin_df, feat, exclude_outliers=exclude,
+                    )
+
+        # Logistic CV: cost-only
+        results[f"logistic_cost_{label_suffix}"] = run_grouped_cv_logistic(
+            sbin_df, ["cost_mean"], n_folds=n_folds, exclude_outliers=exclude,
+        )
+
+        if has_dynamics:
+            # dynamics-only
+            results[f"logistic_dynamics_{label_suffix}"] = run_grouped_cv_logistic(
+                sbin_df, ["disp_mag_mean", "disp_par_mean", "disp_perp_mean"],
+                n_folds=n_folds, exclude_outliers=exclude,
+            )
+            # cost + dynamics
+            results[f"logistic_all_{label_suffix}"] = run_grouped_cv_logistic(
+                sbin_df, ["cost_mean", "disp_mag_mean", "disp_par_mean", "disp_perp_mean"],
+                n_folds=n_folds, exclude_outliers=exclude,
+            )
+
+    return results
+
+
+__all__ = [
+    "compute_auroc_per_bin",
+    "compute_auroc_all_features",
+    "run_grouped_cv_logistic",
+    "run_phase0_classification",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_interval_search.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_interval_search.py
@@ -1,0 +1,251 @@
+"""
+Phase 0 Step 7: 1D Patch (Interval) Search on S.
+
+Finds the contiguous S-bin interval [a..b] that best discriminates
+WT from cep290. Includes sanity checks (only-interval, drop-interval).
+
+Two selection rules:
+  A) Parsimony: smallest interval within ε of best AUROC
+  B) Penalized: maximize AUROC - gamma*(len/K)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import GroupKFold
+
+from roi_config import Phase0IntervalConfig, Phase0IntervalSelectionRule
+
+logger = logging.getLogger(__name__)
+
+
+def _score_interval(
+    sbin_df: pd.DataFrame,
+    bin_start: int,
+    bin_end: int,
+    feature_cols: List[str],
+    n_folds: int = 5,
+    exclude_outliers: bool = True,
+) -> float:
+    """
+    Score a contiguous interval [bin_start, bin_end) via grouped-CV AUROC.
+
+    Uses mean feature over bins in the interval as the per-sample feature.
+    """
+    if exclude_outliers:
+        df = sbin_df[~sbin_df["qc_outlier_flag"]].copy()
+    else:
+        df = sbin_df.copy()
+
+    # Filter to bins in interval
+    interval_df = df[(df["k_bin"] >= bin_start) & (df["k_bin"] < bin_end)]
+    if len(interval_df) == 0:
+        return 0.5
+
+    # Aggregate: mean feature per sample over bins in interval
+    agg_cols = {col: "mean" for col in feature_cols if col in interval_df.columns}
+    agg_cols["label_int"] = "first"
+    agg_cols["embryo_id"] = "first"
+    sample_df = interval_df.groupby("sample_id").agg(agg_cols).reset_index()
+
+    X = sample_df[list(agg_cols.keys() - {"label_int", "embryo_id"})].values
+    y = sample_df["label_int"].values
+    groups = sample_df["embryo_id"].values
+
+    if len(np.unique(y)) < 2:
+        return 0.5
+
+    n_unique = len(np.unique(groups))
+    actual_folds = min(n_folds, n_unique)
+    if actual_folds < 2:
+        return 0.5
+
+    gkf = GroupKFold(n_splits=actual_folds)
+    aurocs = []
+
+    for train_idx, val_idx in gkf.split(X, y, groups):
+        y_train, y_val = y[train_idx], y[val_idx]
+        if len(np.unique(y_train)) < 2 or len(np.unique(y_val)) < 2:
+            continue
+        clf = LogisticRegression(class_weight="balanced", max_iter=1000, random_state=42)
+        clf.fit(X[train_idx], y_train)
+        aurocs.append(roc_auc_score(y_val, clf.predict_proba(X[val_idx])[:, 1]))
+
+    return float(np.mean(aurocs)) if aurocs else 0.5
+
+
+def search_all_intervals(
+    sbin_df: pd.DataFrame,
+    feature_cols: List[str] = ["cost_mean"],
+    K: int = 10,
+    n_folds: int = 5,
+    min_bins: int = 1,
+    max_bins: Optional[int] = None,
+    exclude_outliers: bool = True,
+) -> pd.DataFrame:
+    """
+    Brute-force search over all contiguous S-bin intervals.
+
+    Returns DataFrame with columns: bin_start, bin_end, n_bins, auroc.
+    """
+    if max_bins is None:
+        max_bins = K
+
+    rows = []
+    total_intervals = sum(1 for a in range(K) for b in range(a + min_bins, min(a + max_bins, K) + 1))
+    logger.info(f"Searching {total_intervals} intervals (K={K}, bins={min_bins}..{max_bins})")
+
+    count = 0
+    for a in range(K):
+        for b in range(a + min_bins, min(a + max_bins, K) + 1):
+            auroc = _score_interval(
+                sbin_df, a, b, feature_cols,
+                n_folds=n_folds, exclude_outliers=exclude_outliers,
+            )
+            rows.append({
+                "bin_start": a,
+                "bin_end": b,
+                "n_bins": b - a,
+                "S_lo": a / K,
+                "S_hi": b / K,
+                "auroc": auroc,
+            })
+            count += 1
+            if count % 10 == 0:
+                logger.info(f"  interval {count}/{total_intervals}")
+
+    df = pd.DataFrame(rows).sort_values("auroc", ascending=False).reset_index(drop=True)
+    logger.info(f"Interval search complete: best AUROC={df['auroc'].iloc[0]:.4f}")
+    return df
+
+
+def select_best_interval(
+    interval_df: pd.DataFrame,
+    config: Phase0IntervalConfig = Phase0IntervalConfig(),
+    K: int = 10,
+) -> Dict:
+    """
+    Apply deterministic selection rule to choose best interval.
+
+    Returns dict with selected interval info.
+    """
+    df = interval_df.copy()
+
+    if config.selection_rule == Phase0IntervalSelectionRule.PARSIMONY:
+        # Smallest interval within ε of best AUROC
+        best_auroc = df["auroc"].max()
+        threshold = best_auroc - config.epsilon_auroc
+        candidates = df[df["auroc"] >= threshold]
+        # Among candidates, pick smallest interval; ties broken by highest AUROC
+        selected = candidates.sort_values(
+            ["n_bins", "auroc"], ascending=[True, False]
+        ).iloc[0]
+
+    elif config.selection_rule == Phase0IntervalSelectionRule.PENALIZED:
+        # Maximize AUROC - gamma * (len/K)
+        df["score"] = df["auroc"] - config.gamma_penalty * (df["n_bins"] / K)
+        selected = df.sort_values("score", ascending=False).iloc[0]
+
+    else:
+        raise ValueError(f"Unknown selection rule: {config.selection_rule}")
+
+    result = {
+        "bin_start": int(selected["bin_start"]),
+        "bin_end": int(selected["bin_end"]),
+        "n_bins": int(selected["n_bins"]),
+        "S_lo": float(selected["S_lo"]),
+        "S_hi": float(selected["S_hi"]),
+        "auroc": float(selected["auroc"]),
+        "selection_rule": config.selection_rule.value,
+    }
+
+    logger.info(
+        f"Selected interval: bins [{result['bin_start']}, {result['bin_end']}), "
+        f"S=[{result['S_lo']:.2f}, {result['S_hi']:.2f}), "
+        f"AUROC={result['auroc']:.4f}"
+    )
+    return result
+
+
+def run_sanity_checks(
+    sbin_df: pd.DataFrame,
+    selected: Dict,
+    feature_cols: List[str] = ["cost_mean"],
+    n_folds: int = 5,
+    K: int = 10,
+    exclude_outliers: bool = True,
+) -> Dict:
+    """
+    Sanity checks on the selected interval.
+
+    - Only-interval: keep bins in I, zero others → AUROC should stay high
+    - Drop-interval: zero bins in I, keep others → AUROC should drop
+    """
+    bin_start = selected["bin_start"]
+    bin_end = selected["bin_end"]
+
+    # Score: only-interval
+    only_auroc = _score_interval(
+        sbin_df, bin_start, bin_end, feature_cols,
+        n_folds=n_folds, exclude_outliers=exclude_outliers,
+    )
+
+    # Score: complement (drop-interval)
+    # Use bins OUTSIDE the interval
+    complement_df = sbin_df[
+        (sbin_df["k_bin"] < bin_start) | (sbin_df["k_bin"] >= bin_end)
+    ].copy()
+
+    if len(complement_df) > 0 and complement_df["k_bin"].nunique() > 0:
+        # Re-score the complement as one big interval
+        drop_auroc = _score_interval(
+            sbin_df.copy(),
+            0, K, feature_cols,
+            n_folds=n_folds, exclude_outliers=exclude_outliers,
+        )
+        # Actually, we need to zero the interval bins and score the full set
+        # Simpler: score only complement bins
+        comp_bins = sorted(complement_df["k_bin"].unique())
+        if len(comp_bins) > 0:
+            drop_auroc = _score_interval(
+                complement_df, comp_bins[0], comp_bins[-1] + 1, feature_cols,
+                n_folds=n_folds, exclude_outliers=exclude_outliers,
+            )
+        else:
+            drop_auroc = 0.5
+    else:
+        drop_auroc = 0.5
+
+    # Full model (all bins) for reference
+    full_auroc = _score_interval(
+        sbin_df, 0, K, feature_cols,
+        n_folds=n_folds, exclude_outliers=exclude_outliers,
+    )
+
+    checks = {
+        "only_interval_auroc": only_auroc,
+        "drop_interval_auroc": drop_auroc,
+        "full_auroc": full_auroc,
+        "only_vs_full_diff": only_auroc - full_auroc,
+        "drop_vs_full_diff": drop_auroc - full_auroc,
+        "pass_only_high": only_auroc >= full_auroc - 0.05,
+        "pass_drop_low": drop_auroc < only_auroc - 0.02,
+    }
+
+    logger.info(
+        f"Sanity checks: only={only_auroc:.4f}, drop={drop_auroc:.4f}, full={full_auroc:.4f}"
+    )
+    return checks
+
+
+__all__ = [
+    "search_all_intervals",
+    "select_best_interval",
+    "run_sanity_checks",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_nulls.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_nulls.py
@@ -1,0 +1,252 @@
+"""
+Phase 0 Step 8: Nulls + Stability (selection-aware).
+
+8.1 Permutation null: embryo-level label permutation.
+    Repeats the SAME selection procedure under permuted labels.
+    p-value = fraction of null scores >= observed.
+
+8.2 Bootstrap stability: embryo-level bootstrap within class.
+    Recomputes AUROC_k curves and interval endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+from roi_config import Phase0NullConfig
+from p0_classification import compute_auroc_per_bin, run_grouped_cv_logistic
+from p0_interval_search import search_all_intervals, select_best_interval
+
+logger = logging.getLogger(__name__)
+
+
+def _permute_labels_by_embryo(
+    sbin_df: pd.DataFrame,
+    rng: np.random.Generator,
+) -> pd.DataFrame:
+    """Permute labels at the embryo_id level (maintains within-embryo consistency)."""
+    df = sbin_df.copy()
+    embryo_labels = df.groupby("embryo_id")["label_int"].first()
+    permuted = rng.permutation(embryo_labels.values)
+    label_map = dict(zip(embryo_labels.index, permuted))
+    df["label_int"] = df["embryo_id"].map(label_map)
+    return df
+
+
+def run_permutation_null_auroc_max(
+    sbin_df: pd.DataFrame,
+    observed_max_auroc: float,
+    feature_col: str = "cost_mean",
+    n_permute: int = 200,
+    random_seed: int = 42,
+    exclude_outliers: bool = True,
+) -> Dict:
+    """
+    Selection-aware permutation null for max AUROC_k.
+
+    For each permutation:
+      - Permute labels at embryo level
+      - Compute AUROC per bin
+      - Record max AUROC across bins (selection-aware)
+
+    Returns dict with null distribution and p-value.
+    """
+    rng = np.random.default_rng(random_seed)
+    null_max_aurocs = np.zeros(n_permute)
+
+    for perm_i in range(n_permute):
+        perm_df = _permute_labels_by_embryo(sbin_df, rng)
+        auroc_df = compute_auroc_per_bin(perm_df, feature_col, exclude_outliers=exclude_outliers)
+        null_max_aurocs[perm_i] = auroc_df["auroc"].max()
+
+        if (perm_i + 1) % 50 == 0:
+            logger.info(f"Permutation {perm_i + 1}/{n_permute}")
+
+    pvalue = float(np.mean(null_max_aurocs >= observed_max_auroc))
+
+    result = {
+        "test": "permutation_max_auroc",
+        "statistic": "max_auroc_k",
+        "observed": observed_max_auroc,
+        "null_distribution": null_max_aurocs,
+        "null_mean": float(np.mean(null_max_aurocs)),
+        "null_std": float(np.std(null_max_aurocs)),
+        "pvalue": pvalue,
+        "n_permute": n_permute,
+    }
+
+    logger.info(
+        f"Permutation null (max AUROC): observed={observed_max_auroc:.4f}, "
+        f"null={result['null_mean']:.4f}±{result['null_std']:.4f}, p={pvalue:.4f}"
+    )
+    return result
+
+
+def run_permutation_null_interval(
+    sbin_df: pd.DataFrame,
+    observed_interval_auroc: float,
+    feature_cols: List[str] = ["cost_mean"],
+    interval_config=None,
+    K: int = 10,
+    n_folds: int = 5,
+    n_permute: int = 200,
+    random_seed: int = 42,
+    exclude_outliers: bool = True,
+) -> Dict:
+    """
+    Selection-aware permutation null for best-interval AUROC.
+
+    For each permutation:
+      - Permute labels at embryo level
+      - Run full interval search
+      - Record best-interval AUROC (selection-aware)
+    """
+    from roi_config import Phase0IntervalConfig
+    if interval_config is None:
+        interval_config = Phase0IntervalConfig()
+
+    rng = np.random.default_rng(random_seed)
+    null_aurocs = np.zeros(n_permute)
+
+    for perm_i in range(n_permute):
+        perm_df = _permute_labels_by_embryo(sbin_df, rng)
+        interval_df = search_all_intervals(
+            perm_df, feature_cols, K=K, n_folds=n_folds,
+            exclude_outliers=exclude_outliers,
+        )
+        selected = select_best_interval(interval_df, interval_config, K=K)
+        null_aurocs[perm_i] = selected["auroc"]
+
+        if (perm_i + 1) % 50 == 0:
+            logger.info(f"Permutation (interval) {perm_i + 1}/{n_permute}")
+
+    pvalue = float(np.mean(null_aurocs >= observed_interval_auroc))
+
+    result = {
+        "test": "permutation_best_interval",
+        "statistic": "best_interval_auroc",
+        "observed": observed_interval_auroc,
+        "null_distribution": null_aurocs,
+        "null_mean": float(np.mean(null_aurocs)),
+        "null_std": float(np.std(null_aurocs)),
+        "pvalue": pvalue,
+        "n_permute": n_permute,
+    }
+
+    logger.info(
+        f"Permutation null (interval): observed={observed_interval_auroc:.4f}, "
+        f"null={result['null_mean']:.4f}±{result['null_std']:.4f}, p={pvalue:.4f}"
+    )
+    return result
+
+
+def run_bootstrap_stability(
+    sbin_df: pd.DataFrame,
+    feature_col: str = "cost_mean",
+    feature_cols_interval: List[str] = ["cost_mean"],
+    interval_config=None,
+    K: int = 10,
+    n_folds: int = 5,
+    n_boot: int = 200,
+    random_seed: int = 42,
+    exclude_outliers: bool = True,
+) -> Dict:
+    """
+    Bootstrap stability analysis (embryo-level within-class resampling).
+
+    Recomputes:
+      - AUROC_k curves → confidence bands
+      - Selected interval endpoints → distribution
+      - Interval overlap stability metric
+    """
+    from roi_config import Phase0IntervalConfig
+    if interval_config is None:
+        interval_config = Phase0IntervalConfig()
+
+    if exclude_outliers:
+        df = sbin_df[~sbin_df["qc_outlier_flag"]].copy()
+    else:
+        df = sbin_df.copy()
+
+    rng = np.random.default_rng(random_seed)
+
+    # Get unique embryos per class
+    embryo_labels = df.groupby("embryo_id")["label_int"].first()
+    embryos_0 = embryo_labels[embryo_labels == 0].index.tolist()
+    embryos_1 = embryo_labels[embryo_labels == 1].index.tolist()
+
+    boot_auroc_curves = []  # (n_boot, K)
+    boot_interval_starts = []
+    boot_interval_ends = []
+
+    for boot_i in range(n_boot):
+        # Bootstrap embryos within each class
+        boot_e0 = rng.choice(embryos_0, size=len(embryos_0), replace=True)
+        boot_e1 = rng.choice(embryos_1, size=len(embryos_1), replace=True)
+        boot_embryos = list(boot_e0) + list(boot_e1)
+
+        # Build bootstrap S-bin table
+        boot_rows = []
+        for eid in boot_embryos:
+            boot_rows.append(df[df["embryo_id"] == eid])
+        if not boot_rows:
+            continue
+        boot_df = pd.concat(boot_rows, ignore_index=True)
+
+        # AUROC per bin
+        auroc_df = compute_auroc_per_bin(boot_df, feature_col, exclude_outliers=False)
+        auroc_curve = auroc_df.sort_values("k_bin")["auroc"].values
+        boot_auroc_curves.append(auroc_curve)
+
+        # Interval search
+        try:
+            interval_df = search_all_intervals(
+                boot_df, feature_cols_interval, K=K, n_folds=n_folds,
+                exclude_outliers=False,
+            )
+            selected = select_best_interval(interval_df, interval_config, K=K)
+            boot_interval_starts.append(selected["bin_start"])
+            boot_interval_ends.append(selected["bin_end"])
+        except Exception:
+            pass
+
+        if (boot_i + 1) % 50 == 0:
+            logger.info(f"Bootstrap {boot_i + 1}/{n_boot}")
+
+    # Summarize
+    auroc_matrix = np.array(boot_auroc_curves)  # (n_boot, K)
+    starts = np.array(boot_interval_starts)
+    ends = np.array(boot_interval_ends)
+
+    result = {
+        "auroc_matrix": auroc_matrix,
+        "auroc_mean": np.mean(auroc_matrix, axis=0) if len(auroc_matrix) > 0 else np.zeros(K),
+        "auroc_ci_lo": np.percentile(auroc_matrix, 2.5, axis=0) if len(auroc_matrix) > 0 else np.zeros(K),
+        "auroc_ci_hi": np.percentile(auroc_matrix, 97.5, axis=0) if len(auroc_matrix) > 0 else np.zeros(K),
+        "interval_starts": starts,
+        "interval_ends": ends,
+        "interval_start_mean": float(np.mean(starts)) if len(starts) > 0 else np.nan,
+        "interval_end_mean": float(np.mean(ends)) if len(ends) > 0 else np.nan,
+        "interval_start_std": float(np.std(starts)) if len(starts) > 0 else np.nan,
+        "interval_end_std": float(np.std(ends)) if len(ends) > 0 else np.nan,
+        "n_boot": n_boot,
+        "n_boot_completed": len(auroc_matrix),
+    }
+
+    logger.info(
+        f"Bootstrap stability: {result['n_boot_completed']}/{n_boot} completed, "
+        f"interval start={result['interval_start_mean']:.1f}±{result['interval_start_std']:.1f}"
+    )
+    return result
+
+
+__all__ = [
+    "run_permutation_null_auroc_max",
+    "run_permutation_null_interval",
+    "run_bootstrap_stability",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_ot_maps.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_ot_maps.py
@@ -1,0 +1,158 @@
+"""
+Phase 0 Step 1: Generate OT maps (fixed WT reference → many targets).
+
+Wraps the existing UOT pipeline to produce per-sample feature maps
+on the 512×512 canonical grid. Outputs cost_density, displacement field,
+and delta_mass per sample.
+
+Usage:
+    from p0_ot_maps import generate_ot_maps
+    results = generate_ot_maps(mask_ref, target_masks, config)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from roi_config import (
+    FeatureDatasetConfig,
+    Phase0FeatureSet,
+    PHASE0_CHANNEL_SCHEMAS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OTMapResult:
+    """Result from a single ref→target OT computation."""
+    sample_id: str
+    cost_density: np.ndarray       # (512, 512) float32
+    displacement_yx: np.ndarray    # (512, 512, 2) float32 — (v, u) convention
+    delta_mass: np.ndarray         # (512, 512) float32 — created - destroyed
+    total_cost_C: float
+    diagnostics: Dict
+
+
+def _compute_ot_params_hash(config_dict: dict) -> str:
+    """Deterministic hash of OT parameters for provenance."""
+    raw = json.dumps(config_dict, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def run_single_ot(
+    mask_ref: np.ndarray,
+    mask_target: np.ndarray,
+    sample_id: str,
+    uot_config=None,
+    backend=None,
+) -> OTMapResult:
+    """
+    Run unbalanced OT: ref → target, return canonical-grid maps.
+
+    Uses the existing run_uot_pair() pipeline. mask_ref and mask_target
+    must already be on the 512×512 canonical grid.
+    """
+    from analyze.utils.optimal_transport import UOTConfig, UOTFramePair, UOTFrame
+    from analyze.optimal_transport_morphometrics.uot_masks.run_transport import run_uot_pair
+
+    if uot_config is None:
+        uot_config = UOTConfig(
+            use_pair_frame=True,
+            use_canonical_grid=False,  # masks already canonical
+            downsample_factor=4,
+        )
+
+    pair = UOTFramePair(
+        src=UOTFrame(embryo_mask=mask_ref),
+        tgt=UOTFrame(embryo_mask=mask_target),
+    )
+
+    result = run_uot_pair(pair, config=uot_config, backend=backend)
+
+    # Extract maps (already canonical-shaped if pair_frame was used)
+    cost_density = result.cost_src_px if result.cost_src_px is not None else np.zeros_like(mask_ref, dtype=np.float32)
+    displacement_yx = result.velocity_px_per_frame_yx  # (H, W, 2)
+    delta_mass = result.mass_created_px - result.mass_destroyed_px
+
+    return OTMapResult(
+        sample_id=sample_id,
+        cost_density=cost_density.astype(np.float32),
+        displacement_yx=displacement_yx.astype(np.float32),
+        delta_mass=delta_mass.astype(np.float32),
+        total_cost_C=float(result.cost),
+        diagnostics=result.diagnostics or {},
+    )
+
+
+def generate_ot_maps(
+    mask_ref: np.ndarray,
+    target_masks: List[np.ndarray],
+    sample_ids: List[str],
+    feature_set: Phase0FeatureSet = Phase0FeatureSet.V0_COST,
+    uot_config=None,
+    backend=None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Run OT for all targets against fixed reference, return feature array X and total_cost_C.
+
+    Parameters
+    ----------
+    mask_ref : (512, 512) uint8
+    target_masks : list of (512, 512) uint8, length N
+    sample_ids : list of str, length N
+    feature_set : Phase0FeatureSet
+
+    Returns
+    -------
+    X : (N, 512, 512, C) float32 — feature maps per sample
+    total_cost_C : (N,) float32 — total OT cost per sample
+    """
+    N = len(target_masks)
+    assert len(sample_ids) == N
+    H, W = mask_ref.shape
+    channel_schemas = PHASE0_CHANNEL_SCHEMAS[feature_set]
+    C = len(channel_schemas)
+
+    X = np.zeros((N, H, W, C), dtype=np.float32)
+    total_cost_C = np.zeros(N, dtype=np.float32)
+
+    for i, (mask_tgt, sid) in enumerate(zip(target_masks, sample_ids)):
+        logger.info(f"OT map {i+1}/{N}: {sid}")
+
+        ot_result = run_single_ot(
+            mask_ref, mask_tgt, sid,
+            uot_config=uot_config, backend=backend,
+        )
+
+        total_cost_C[i] = ot_result.total_cost_C
+
+        if feature_set == Phase0FeatureSet.V0_COST:
+            X[i, :, :, 0] = ot_result.cost_density
+        elif feature_set == Phase0FeatureSet.V1_DYNAMICS:
+            X[i, :, :, 0] = ot_result.cost_density
+            X[i, :, :, 1] = ot_result.displacement_yx[:, :, 1]  # disp_u (x)
+            X[i, :, :, 2] = ot_result.displacement_yx[:, :, 0]  # disp_v (y)
+            X[i, :, :, 3] = np.sqrt(
+                ot_result.displacement_yx[:, :, 0]**2
+                + ot_result.displacement_yx[:, :, 1]**2
+            )  # disp_mag
+            X[i, :, :, 4] = ot_result.delta_mass
+
+    logger.info(f"Generated OT maps: X shape={X.shape}, mean cost={total_cost_C.mean():.4f}")
+    return X, total_cost_C
+
+
+__all__ = [
+    "OTMapResult",
+    "run_single_ot",
+    "generate_ot_maps",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_qc.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_qc.py
@@ -1,0 +1,290 @@
+"""
+Phase 0 Step 2: QC + Outlier Filtering.
+
+Provides IQR-based outlier flagging on total_cost_C and the three
+required QC deliverables (gate to proceed):
+  QC-1: histogram/violin of total_cost_C (before/after filtering)
+  QC-2: montage of top-N highest-cost samples with their cost maps
+  QC-3: summary table of dropped samples
+
+Gate: post-filter mean maps must not be dominated by alignment failures.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+
+logger = logging.getLogger(__name__)
+
+
+def compute_iqr_outliers(
+    total_cost_C: np.ndarray,
+    multiplier: float = 1.5,
+) -> Tuple[np.ndarray, Dict]:
+    """
+    Flag outliers using IQR method on total_cost_C.
+
+    Returns
+    -------
+    outlier_flag : (N,) bool
+    stats : dict with q1, q3, iqr, lower, upper, n_outliers
+    """
+    q1 = float(np.percentile(total_cost_C, 25))
+    q3 = float(np.percentile(total_cost_C, 75))
+    iqr = q3 - q1
+    lower = q1 - multiplier * iqr
+    upper = q3 + multiplier * iqr
+    outlier_flag = (total_cost_C < lower) | (total_cost_C > upper)
+
+    stats = {
+        "q1": q1, "q3": q3, "iqr": iqr,
+        "lower_bound": lower, "upper_bound": upper,
+        "n_total": len(total_cost_C),
+        "n_outliers": int(outlier_flag.sum()),
+        "n_retained": int((~outlier_flag).sum()),
+        "multiplier": multiplier,
+    }
+    logger.info(
+        f"IQR QC: {stats['n_outliers']}/{stats['n_total']} flagged "
+        f"(bounds=[{lower:.4f}, {upper:.4f}])"
+    )
+    return outlier_flag, stats
+
+
+def plot_qc1_cost_histogram(
+    total_cost_C: np.ndarray,
+    outlier_flag: np.ndarray,
+    stats: Dict,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """
+    QC-1: Histogram/violin of total_cost_C showing before/after filtering.
+    """
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Left: full distribution with outlier bounds
+    ax = axes[0]
+    ax.hist(total_cost_C, bins=40, alpha=0.7, color="steelblue", edgecolor="k",
+            label="All samples")
+    ax.axvline(stats["lower_bound"], color="red", linestyle="--", linewidth=1.5,
+               label=f"IQR bounds (×{stats['multiplier']:.1f})")
+    ax.axvline(stats["upper_bound"], color="red", linestyle="--", linewidth=1.5)
+    ax.axvline(stats["q1"], color="orange", linestyle=":", alpha=0.7, label="Q1/Q3")
+    ax.axvline(stats["q3"], color="orange", linestyle=":", alpha=0.7)
+
+    # Mark outliers
+    outlier_costs = total_cost_C[outlier_flag]
+    if len(outlier_costs) > 0:
+        ax.hist(outlier_costs, bins=40, alpha=0.5, color="red", edgecolor="k",
+                label=f"Outliers ({stats['n_outliers']})")
+    ax.set_xlabel("Total OT Cost (C)")
+    ax.set_ylabel("Count")
+    ax.set_title(f"QC-1: Total Cost Distribution\n"
+                 f"N={stats['n_total']}, outliers={stats['n_outliers']}")
+    ax.legend(fontsize=8)
+
+    # Right: retained only
+    ax = axes[1]
+    retained = total_cost_C[~outlier_flag]
+    ax.hist(retained, bins=40, alpha=0.7, color="seagreen", edgecolor="k")
+    ax.set_xlabel("Total OT Cost (C)")
+    ax.set_ylabel("Count")
+    ax.set_title(f"QC-1: After Filtering (N={stats['n_retained']})")
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved QC-1: {save_path}")
+    return fig
+
+
+def plot_qc2_worst_samples(
+    X: np.ndarray,
+    total_cost_C: np.ndarray,
+    mask_ref: np.ndarray,
+    sample_ids: List[str],
+    top_n: int = 8,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """
+    QC-2: Montage of top-N highest-cost samples with their cost density maps.
+
+    X : (N, 512, 512, C) — channel 0 is cost_density
+    """
+    order = np.argsort(total_cost_C)[::-1][:top_n]
+
+    ncols = min(4, top_n)
+    nrows = (top_n + ncols - 1) // ncols
+    fig, axes = plt.subplots(nrows, ncols, figsize=(4 * ncols, 4 * nrows))
+    if nrows == 1 and ncols == 1:
+        axes = np.array([[axes]])
+    elif nrows == 1:
+        axes = axes[np.newaxis, :]
+    elif ncols == 1:
+        axes = axes[:, np.newaxis]
+
+    for idx, rank in enumerate(range(top_n)):
+        if rank >= len(order):
+            break
+        i = order[rank]
+        r, c = divmod(idx, ncols)
+        ax = axes[r, c]
+
+        cost_map = X[i, :, :, 0]
+        # Mask outside embryo
+        display = np.where(mask_ref.astype(bool), cost_map, np.nan)
+        im = ax.imshow(display, cmap="hot", interpolation="nearest")
+        ax.set_title(f"#{rank+1}: {sample_ids[i]}\nC={total_cost_C[i]:.4f}", fontsize=8)
+        ax.axis("off")
+        plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # Turn off unused axes
+    for idx in range(top_n, nrows * ncols):
+        r, c = divmod(idx, ncols)
+        axes[r, c].axis("off")
+
+    fig.suptitle(f"QC-2: Top-{top_n} Highest Cost Samples", fontsize=12, fontweight="bold")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved QC-2: {save_path}")
+    return fig
+
+
+def build_qc3_dropped_table(
+    metadata_df: pd.DataFrame,
+    outlier_flag: np.ndarray,
+    total_cost_C: np.ndarray,
+) -> pd.DataFrame:
+    """
+    QC-3: Summary table of dropped samples.
+
+    Returns DataFrame with columns: sample_id, embryo_id, snip_id, total_cost_C, reason.
+    """
+    dropped = metadata_df[outlier_flag].copy()
+    dropped["total_cost_C"] = total_cost_C[outlier_flag]
+    dropped["reason"] = "IQR_outlier"
+
+    # Sort by cost descending
+    dropped = dropped.sort_values("total_cost_C", ascending=False).reset_index(drop=True)
+    logger.info(f"QC-3: {len(dropped)} dropped samples")
+    return dropped
+
+
+def plot_qc_mean_maps(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    outlier_flag: np.ndarray,
+    label_names: Dict[int, str] = None,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """
+    Post-filter mean cost density maps by class (gate visual check).
+
+    Shows WT mean, mutant mean, and difference. This is the gate check:
+    if these are dominated by alignment failures, do NOT proceed.
+    """
+    if label_names is None:
+        label_names = {0: "WT", 1: "cep290"}
+
+    valid = ~outlier_flag
+    X_valid = X[valid]
+    y_valid = y[valid]
+    cost_ch = X_valid[:, :, :, 0]  # channel 0 = cost_density
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5))
+
+    for label_int, label_str in label_names.items():
+        mask_class = y_valid == label_int
+        if mask_class.sum() == 0:
+            continue
+        mean_map = np.mean(cost_ch[mask_class], axis=0)
+        mean_map = np.where(mask_ref.astype(bool), mean_map, np.nan)
+
+        ax_idx = label_int  # 0=WT, 1=mutant
+        im = axes[ax_idx].imshow(mean_map, cmap="hot", interpolation="bilinear")
+        axes[ax_idx].set_title(f"Mean Cost: {label_str} (n={mask_class.sum()})")
+        axes[ax_idx].axis("off")
+        plt.colorbar(im, ax=axes[ax_idx], fraction=0.046, pad=0.04)
+
+    # Difference
+    wt_mask = y_valid == 0
+    mut_mask = y_valid == 1
+    if wt_mask.sum() > 0 and mut_mask.sum() > 0:
+        diff = np.mean(cost_ch[mut_mask], axis=0) - np.mean(cost_ch[wt_mask], axis=0)
+        diff = np.where(mask_ref.astype(bool), diff, np.nan)
+        vabs = np.nanmax(np.abs(diff)) if np.any(np.isfinite(diff)) else 1.0
+        im = axes[2].imshow(diff, cmap="RdBu_r", vmin=-vabs, vmax=vabs,
+                            interpolation="bilinear")
+        axes[2].set_title(f"Difference ({label_names[1]} − {label_names[0]})")
+        axes[2].axis("off")
+        plt.colorbar(im, ax=axes[2], fraction=0.046, pad=0.04, label="Δ cost")
+
+    fig.suptitle("QC Gate: Post-Filter Mean Cost Maps", fontsize=12, fontweight="bold")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        logger.info(f"Saved QC mean maps: {save_path}")
+    return fig
+
+
+def run_qc_suite(
+    X: np.ndarray,
+    y: np.ndarray,
+    total_cost_C: np.ndarray,
+    mask_ref: np.ndarray,
+    metadata_df: pd.DataFrame,
+    sample_ids: List[str],
+    out_dir: str | Path,
+    iqr_multiplier: float = 1.5,
+) -> Tuple[np.ndarray, Dict]:
+    """
+    Run the full QC suite (steps 2.1 + 2.2 from Phase 0 spec).
+
+    Returns outlier_flag and stats dict.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # 2.1 IQR filter
+    outlier_flag, stats = compute_iqr_outliers(total_cost_C, multiplier=iqr_multiplier)
+
+    # 2.2 QC deliverables
+    plot_qc1_cost_histogram(total_cost_C, outlier_flag, stats,
+                            save_path=out_dir / "qc1_cost_histogram.png")
+    plot_qc2_worst_samples(X, total_cost_C, mask_ref, sample_ids,
+                           save_path=out_dir / "qc2_worst_samples.png")
+
+    dropped_df = build_qc3_dropped_table(metadata_df, outlier_flag, total_cost_C)
+    dropped_df.to_csv(out_dir / "qc3_dropped_samples.csv", index=False)
+
+    # Gate check: mean maps
+    plot_qc_mean_maps(X, y, mask_ref, outlier_flag,
+                      save_path=out_dir / "qc_gate_mean_maps.png")
+
+    plt.close("all")
+    logger.info(f"QC suite complete: {out_dir}")
+    return outlier_flag, stats
+
+
+__all__ = [
+    "compute_iqr_outliers",
+    "plot_qc1_cost_histogram",
+    "plot_qc2_worst_samples",
+    "build_qc3_dropped_table",
+    "plot_qc_mean_maps",
+    "run_qc_suite",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_s_coordinate.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_s_coordinate.py
@@ -1,0 +1,229 @@
+"""
+Phase 0 Step 4: Compute S coordinate map on the WT reference template.
+
+Produces S_map_ref(x,y) in [0,1] for each pixel in mask_ref, where
+S=0 is head (rostral) and S=1 is tail (caudal).
+
+Also computes optional local basis vectors (tangent_ref, normal_ref)
+for projecting displacement vectors into parallel/perpendicular components.
+
+Uses the existing centerline extraction API from:
+    segmentation_sandbox/scripts/body_axis_analysis/centerline_extraction.py
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+from scipy.interpolate import splprep, splev
+from scipy.spatial import cKDTree
+
+from roi_config import Phase0SCoordinateConfig
+
+logger = logging.getLogger(__name__)
+
+
+def extract_centerline_from_mask(
+    mask_ref: np.ndarray,
+    config: Phase0SCoordinateConfig = Phase0SCoordinateConfig(),
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Extract a smoothed centerline from the reference mask.
+
+    Returns (spline_x, spline_y, curvature, arc_length).
+    Orientation: head-to-tail (S=0 head, S=1 tail).
+    """
+    try:
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "segmentation_sandbox" / "scripts"))
+        from body_axis_analysis.centerline_extraction import extract_centerline
+
+        spline_x, spline_y, curvature, arc_length = extract_centerline(
+            mask_ref,
+            method=config.centerline_method,
+            orient_head_to_tail=config.orient_head_to_tail,
+            bspline_smoothing=config.bspline_smoothing,
+            random_seed=config.random_seed,
+        )
+        logger.info(
+            f"Centerline extracted: {len(spline_x)} points, "
+            f"length={arc_length[-1]:.1f} px"
+        )
+        return spline_x, spline_y, curvature, arc_length
+
+    except ImportError:
+        logger.warning("body_axis_analysis not available, using PCA fallback")
+        return _pca_centerline_fallback(mask_ref)
+
+
+def _pca_centerline_fallback(mask_ref: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Simple PCA-based centerline when the full analyzer isn't available."""
+    ys, xs = np.where(mask_ref > 0)
+    if len(ys) == 0:
+        raise ValueError("Empty mask")
+
+    coords = np.column_stack([xs, ys]).astype(float)
+    centroid = coords.mean(axis=0)
+    centered = coords - centroid
+
+    # PCA
+    cov = np.cov(centered.T)
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    pc1 = eigvecs[:, -1]  # principal component
+
+    # Project onto PC1
+    projections = centered @ pc1
+    order = np.argsort(projections)
+    sorted_coords = coords[order]
+
+    # Subsample for smoothing
+    n_pts = min(200, len(sorted_coords))
+    indices = np.linspace(0, len(sorted_coords) - 1, n_pts, dtype=int)
+    pts = sorted_coords[indices]
+
+    # B-spline fit
+    tck, u = splprep([pts[:, 0], pts[:, 1]], s=len(pts) * 5, k=3)
+    u_fine = np.linspace(0, 1, 500)
+    spline_x, spline_y = splev(u_fine, tck)
+
+    # Arc length
+    dx = np.diff(spline_x)
+    dy = np.diff(spline_y)
+    ds = np.sqrt(dx**2 + dy**2)
+    arc_length = np.concatenate([[0], np.cumsum(ds)])
+
+    # Curvature (finite differences)
+    ddx = np.gradient(np.gradient(spline_x))
+    ddy = np.gradient(np.gradient(spline_y))
+    dx1 = np.gradient(spline_x)
+    dy1 = np.gradient(spline_y)
+    curvature = np.abs(dx1 * ddy - dy1 * ddx) / (dx1**2 + dy1**2 + 1e-12)**1.5
+
+    return np.array(spline_x), np.array(spline_y), curvature, arc_length
+
+
+def compute_s_map(
+    mask_ref: np.ndarray,
+    spline_x: np.ndarray,
+    spline_y: np.ndarray,
+    arc_length: np.ndarray,
+) -> np.ndarray:
+    """
+    Compute S_map_ref(x,y) in [0,1] for each pixel in mask_ref.
+
+    For each mask pixel, find its nearest point on the spline and assign
+    the normalized arc-length parameter.
+
+    Returns S_map of shape (H, W) with S in [0,1] inside mask, NaN outside.
+    """
+    H, W = mask_ref.shape
+    S_map = np.full((H, W), np.nan, dtype=np.float32)
+
+    ys, xs = np.where(mask_ref > 0)
+    if len(ys) == 0:
+        return S_map
+
+    # Build KD-tree on spline points
+    spline_pts = np.column_stack([spline_x, spline_y])
+    tree = cKDTree(spline_pts)
+
+    # Query nearest spline point for each mask pixel
+    pixel_pts = np.column_stack([xs, ys])
+    _, nearest_idx = tree.query(pixel_pts)
+
+    # Normalize arc length to [0,1]
+    total_length = arc_length[-1]
+    if total_length > 0:
+        s_values = arc_length[nearest_idx] / total_length
+    else:
+        s_values = np.zeros(len(nearest_idx))
+
+    S_map[ys, xs] = s_values.astype(np.float32)
+
+    logger.info(
+        f"S_map computed: {len(ys)} pixels, S range=[{np.nanmin(S_map):.3f}, {np.nanmax(S_map):.3f}]"
+    )
+    return S_map
+
+
+def compute_local_basis(
+    mask_ref: np.ndarray,
+    spline_x: np.ndarray,
+    spline_y: np.ndarray,
+    S_map: np.ndarray,
+    arc_length: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Compute local tangent and normal basis vectors at each mask pixel.
+
+    tangent_ref[y,x] = unit tangent e_parallel at S(x,y) along the spline
+    normal_ref[y,x] = unit normal e_perp (90° CCW from tangent)
+
+    Returns (tangent_ref, normal_ref), each shape (H, W, 2).
+    """
+    H, W = mask_ref.shape
+    tangent_ref = np.zeros((H, W, 2), dtype=np.float32)
+    normal_ref = np.zeros((H, W, 2), dtype=np.float32)
+
+    # Compute tangent along spline via finite differences
+    dx = np.gradient(spline_x)
+    dy = np.gradient(spline_y)
+    mag = np.sqrt(dx**2 + dy**2) + 1e-12
+    tangent_x = dx / mag
+    tangent_y = dy / mag
+
+    ys, xs = np.where(mask_ref > 0)
+    if len(ys) == 0:
+        return tangent_ref, normal_ref
+
+    # For each pixel, find nearest spline point
+    spline_pts = np.column_stack([spline_x, spline_y])
+    tree = cKDTree(spline_pts)
+    pixel_pts = np.column_stack([xs, ys])
+    _, nearest_idx = tree.query(pixel_pts)
+
+    # Assign tangent/normal from nearest spline point
+    tangent_ref[ys, xs, 0] = tangent_x[nearest_idx]
+    tangent_ref[ys, xs, 1] = tangent_y[nearest_idx]
+
+    # Normal = 90° CCW rotation of tangent: (-ty, tx)
+    normal_ref[ys, xs, 0] = -tangent_y[nearest_idx]
+    normal_ref[ys, xs, 1] = tangent_x[nearest_idx]
+
+    logger.info(f"Local basis computed for {len(ys)} pixels")
+    return tangent_ref, normal_ref
+
+
+def build_s_coordinate(
+    mask_ref: np.ndarray,
+    config: Phase0SCoordinateConfig = Phase0SCoordinateConfig(),
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
+    """
+    Full S coordinate computation: centerline → S_map → basis.
+
+    Returns (S_map_ref, tangent_ref, normal_ref, info_dict).
+    """
+    spline_x, spline_y, curvature, arc_length = extract_centerline_from_mask(mask_ref, config)
+    S_map = compute_s_map(mask_ref, spline_x, spline_y, arc_length)
+    tangent_ref, normal_ref = compute_local_basis(mask_ref, spline_x, spline_y, S_map, arc_length)
+
+    info = {
+        "centerline_method": config.centerline_method,
+        "n_spline_points": len(spline_x),
+        "total_length_px": float(arc_length[-1]),
+        "mean_curvature": float(np.mean(curvature)),
+        "max_curvature": float(np.max(curvature)),
+    }
+
+    return S_map, tangent_ref, normal_ref, info
+
+
+__all__ = [
+    "extract_centerline_from_mask",
+    "compute_s_map",
+    "compute_local_basis",
+    "build_s_coordinate",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_sbin_features.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_sbin_features.py
@@ -1,0 +1,202 @@
+"""
+Phase 0 Step 5: Build the S-bin feature table.
+
+Aggregates per-pixel OT feature maps into per-sample-per-bin summaries.
+Output: features_sbins.parquet (tiny table, fast, reusable).
+
+All summaries computed on UNSMOOTHED maps (smoothing is visualization-only).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from roi_config import Phase0FeatureSet, Phase0SBinConfig
+
+logger = logging.getLogger(__name__)
+
+
+def define_bins(K: int) -> List[Tuple[float, float]]:
+    """Define K uniform bins on S ∈ [0, 1). Returns list of (S_lo, S_hi)."""
+    return [(k / K, (k + 1) / K) for k in range(K)]
+
+
+def compute_bin_mask(S_map: np.ndarray, S_lo: float, S_hi: float) -> np.ndarray:
+    """Return boolean mask for pixels in bin [S_lo, S_hi)."""
+    valid = np.isfinite(S_map)
+    return valid & (S_map >= S_lo) & (S_map < S_hi)
+
+
+def build_sbin_features_v0(
+    X: np.ndarray,
+    y: np.ndarray,
+    S_map_ref: np.ndarray,
+    metadata_df: pd.DataFrame,
+    outlier_flag: np.ndarray,
+    K: int = 10,
+) -> pd.DataFrame:
+    """
+    Build S-bin feature table (v0: cost_mean only).
+
+    Parameters
+    ----------
+    X : (N, 512, 512, C) — channel 0 is cost_density
+    y : (N,) int
+    S_map_ref : (512, 512) float32 in [0,1]
+    metadata_df : DataFrame with sample_id, embryo_id, etc.
+    outlier_flag : (N,) bool
+    K : number of bins
+
+    Returns
+    -------
+    DataFrame with N×K rows
+    """
+    N = X.shape[0]
+    bins = define_bins(K)
+    rows = []
+
+    for i in range(N):
+        meta = metadata_df.iloc[i]
+        for k, (s_lo, s_hi) in enumerate(bins):
+            bin_mask = compute_bin_mask(S_map_ref, s_lo, s_hi)
+            n_pixels = int(bin_mask.sum())
+
+            cost_mean = float(np.mean(X[i, bin_mask, 0])) if n_pixels > 0 else 0.0
+
+            rows.append({
+                "sample_id": meta.get("sample_id", f"sample_{i}"),
+                "embryo_id": meta.get("embryo_id", ""),
+                "snip_id": meta.get("snip_id", ""),
+                "label_int": int(y[i]),
+                "qc_outlier_flag": bool(outlier_flag[i]),
+                "k_bin": k,
+                "S_lo": s_lo,
+                "S_hi": s_hi,
+                "n_pixels": n_pixels,
+                "cost_mean": cost_mean,
+            })
+
+    df = pd.DataFrame(rows)
+    logger.info(f"S-bin features (v0): {len(df)} rows ({N} samples × {K} bins)")
+    return df
+
+
+def build_sbin_features_v1(
+    X: np.ndarray,
+    y: np.ndarray,
+    S_map_ref: np.ndarray,
+    tangent_ref: np.ndarray,
+    normal_ref: np.ndarray,
+    metadata_df: pd.DataFrame,
+    outlier_flag: np.ndarray,
+    K: int = 10,
+) -> pd.DataFrame:
+    """
+    Build S-bin feature table (v1: cost + dynamics).
+
+    Requires V1_DYNAMICS channel set (C=5):
+      ch0=cost_density, ch1=disp_u, ch2=disp_v, ch3=disp_mag, ch4=delta_mass
+
+    Computes:
+      - cost_mean
+      - disp_mag_mean
+      - disp_par_mean = mean(displacement · e_parallel)
+      - disp_perp_mean = mean(displacement · e_perp)
+    """
+    N = X.shape[0]
+    bins = define_bins(K)
+    rows = []
+
+    for i in range(N):
+        meta = metadata_df.iloc[i]
+        for k, (s_lo, s_hi) in enumerate(bins):
+            bin_mask = compute_bin_mask(S_map_ref, s_lo, s_hi)
+            n_pixels = int(bin_mask.sum())
+
+            if n_pixels > 0:
+                cost_mean = float(np.mean(X[i, bin_mask, 0]))
+                disp_mag_mean = float(np.mean(X[i, bin_mask, 3]))
+
+                # Project displacement onto local basis
+                disp_u = X[i, bin_mask, 1]  # x component
+                disp_v = X[i, bin_mask, 2]  # y component
+                tan_x = tangent_ref[bin_mask, 0]
+                tan_y = tangent_ref[bin_mask, 1]
+                norm_x = normal_ref[bin_mask, 0]
+                norm_y = normal_ref[bin_mask, 1]
+
+                disp_par = disp_u * tan_x + disp_v * tan_y
+                disp_perp = disp_u * norm_x + disp_v * norm_y
+
+                disp_par_mean = float(np.mean(disp_par))
+                disp_perp_mean = float(np.mean(disp_perp))
+            else:
+                cost_mean = disp_mag_mean = disp_par_mean = disp_perp_mean = 0.0
+
+            rows.append({
+                "sample_id": meta.get("sample_id", f"sample_{i}"),
+                "embryo_id": meta.get("embryo_id", ""),
+                "snip_id": meta.get("snip_id", ""),
+                "label_int": int(y[i]),
+                "qc_outlier_flag": bool(outlier_flag[i]),
+                "k_bin": k,
+                "S_lo": s_lo,
+                "S_hi": s_hi,
+                "n_pixels": n_pixels,
+                "cost_mean": cost_mean,
+                "disp_mag_mean": disp_mag_mean,
+                "disp_par_mean": disp_par_mean,
+                "disp_perp_mean": disp_perp_mean,
+            })
+
+    df = pd.DataFrame(rows)
+    logger.info(f"S-bin features (v1): {len(df)} rows ({N} samples × {K} bins)")
+    return df
+
+
+def build_sbin_features(
+    X: np.ndarray,
+    y: np.ndarray,
+    S_map_ref: np.ndarray,
+    metadata_df: pd.DataFrame,
+    outlier_flag: np.ndarray,
+    feature_set: Phase0FeatureSet = Phase0FeatureSet.V0_COST,
+    K: int = 10,
+    tangent_ref: Optional[np.ndarray] = None,
+    normal_ref: Optional[np.ndarray] = None,
+    save_path: Optional[str | Path] = None,
+) -> pd.DataFrame:
+    """
+    Dispatch to v0 or v1 builder depending on feature_set.
+    """
+    if feature_set == Phase0FeatureSet.V0_COST:
+        df = build_sbin_features_v0(X, y, S_map_ref, metadata_df, outlier_flag, K)
+    elif feature_set == Phase0FeatureSet.V1_DYNAMICS:
+        assert tangent_ref is not None and normal_ref is not None, \
+            "V1_DYNAMICS requires tangent_ref and normal_ref"
+        df = build_sbin_features_v1(
+            X, y, S_map_ref, tangent_ref, normal_ref,
+            metadata_df, outlier_flag, K,
+        )
+    else:
+        raise ValueError(f"Unknown feature_set: {feature_set}")
+
+    if save_path:
+        df.to_parquet(save_path, index=False)
+        logger.info(f"Saved S-bin features: {save_path}")
+
+    return df
+
+
+__all__ = [
+    "define_bins",
+    "compute_bin_mask",
+    "build_sbin_features_v0",
+    "build_sbin_features_v1",
+    "build_sbin_features",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_viz.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/p0_viz.py
@@ -1,0 +1,494 @@
+"""
+Phase 0 Visualization (Section 3 of PHASE0_SPEC).
+
+Provides the main debugging/reporting figures for Phase 0:
+  3.1 Cost density maps (mean WT, mean cep290, difference, smoothed contours)
+  3.2 Displacement dynamics maps (quiver + magnitude)
+  AUROC vs S-bin curves
+  Logistic coefficient profiles
+  Interval search results
+  Null distribution histograms
+  Bootstrap confidence bands
+
+All visual smoothing is for display only — stats use unsmoothed data.
+
+Preferred clean style:
+  - embryo outline (mask_ref boundary)
+  - filled contours (smoothed scalar field)
+  - thin contour lines on top (same levels)
+  - consistent color scale across WT/mutant/diff
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.ndimage import gaussian_filter
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+import matplotlib.cm as cm
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _embryo_outline(mask_ref: np.ndarray, ax: plt.Axes, color: str = "white", lw: float = 1.0):
+    """Draw embryo outline (mask_ref boundary) on axes."""
+    ax.contour(mask_ref.astype(float), levels=[0.5], colors=[color],
+               linewidths=lw, linestyles="-")
+
+
+def _apply_mask_nan(field: np.ndarray, mask_ref: np.ndarray) -> np.ndarray:
+    """Mask field outside embryo with NaN."""
+    return np.where(mask_ref.astype(bool), field, np.nan)
+
+
+# ---------------------------------------------------------------------------
+# 3.1 Cost density maps
+# ---------------------------------------------------------------------------
+
+def plot_cost_density_suite(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    outlier_flag: np.ndarray,
+    sigma_grid: Tuple[float, ...] = (1.0, 2.0, 4.0),
+    label_names: Dict[int, str] = None,
+    save_dir: Optional[str | Path] = None,
+) -> Dict[str, plt.Figure]:
+    """
+    Figs A1–A6: Mean cost density maps (raw + smoothed contour versions).
+    """
+    if label_names is None:
+        label_names = {0: "WT", 1: "cep290"}
+    if save_dir:
+        save_dir = Path(save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+    valid = ~outlier_flag
+    X_valid = X[valid]
+    y_valid = y[valid]
+    cost_ch = X_valid[:, :, :, 0]
+    mask_bool = mask_ref.astype(bool)
+
+    # Compute means
+    means = {}
+    for label_int, label_str in label_names.items():
+        sel = y_valid == label_int
+        if sel.sum() > 0:
+            means[label_str] = np.mean(cost_ch[sel], axis=0)
+        else:
+            means[label_str] = np.zeros_like(mask_ref, dtype=np.float32)
+
+    diff = means.get(label_names[1], np.zeros_like(mask_ref)) - means.get(label_names[0], np.zeros_like(mask_ref))
+
+    figs = {}
+
+    # A1-A3: Raw mean maps
+    fig_raw, axes = plt.subplots(1, 3, figsize=(18, 5))
+    vmax_raw = max(np.nanmax(_apply_mask_nan(m, mask_ref)) for m in means.values() if np.any(np.isfinite(_apply_mask_nan(m, mask_ref))))
+
+    for idx, (label_str, mean_map) in enumerate(means.items()):
+        ax = axes[idx]
+        display = _apply_mask_nan(mean_map, mask_ref)
+        im = ax.imshow(display, cmap="hot", vmin=0, vmax=vmax_raw, interpolation="bilinear")
+        _embryo_outline(mask_ref, ax)
+        ax.set_title(f"Fig A{idx+1}: Mean Cost — {label_str}")
+        ax.axis("off")
+        plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # A3: difference
+    diff_display = _apply_mask_nan(diff, mask_ref)
+    vabs = np.nanmax(np.abs(diff_display)) if np.any(np.isfinite(diff_display)) else 1.0
+    im = axes[2].imshow(diff_display, cmap="RdBu_r", vmin=-vabs, vmax=vabs, interpolation="bilinear")
+    _embryo_outline(mask_ref, axes[2], color="black")
+    axes[2].set_title(f"Fig A3: Difference ({label_names[1]} − {label_names[0]})")
+    axes[2].axis("off")
+    plt.colorbar(im, ax=axes[2], fraction=0.046, pad=0.04, label="Δ cost")
+
+    fig_raw.tight_layout()
+    figs["cost_raw"] = fig_raw
+    if save_dir:
+        fig_raw.savefig(save_dir / "fig_A1_A3_cost_density_raw.png", dpi=150, bbox_inches="tight")
+
+    # A4-A6: Smoothed contour versions
+    for sigma in sigma_grid:
+        fig_smooth, axes_s = plt.subplots(1, 3, figsize=(18, 5))
+
+        for idx, (label_str, mean_map) in enumerate(means.items()):
+            ax = axes_s[idx]
+            smoothed = gaussian_filter(mean_map * mask_bool, sigma=sigma)
+            smoothed = _apply_mask_nan(smoothed, mask_ref)
+            levels = np.linspace(0, vmax_raw, 12)
+
+            ax.contourf(smoothed, levels=levels, cmap="hot", origin="upper")
+            ax.contour(smoothed, levels=levels, colors="k", linewidths=0.3, origin="upper")
+            _embryo_outline(mask_ref, ax, color="white", lw=1.5)
+            ax.set_title(f"{label_str} (σ={sigma})")
+            ax.axis("off")
+
+        # Difference contour
+        diff_smoothed = gaussian_filter(diff * mask_bool, sigma=sigma)
+        diff_smoothed = _apply_mask_nan(diff_smoothed, mask_ref)
+        levels_diff = np.linspace(-vabs, vabs, 15)
+
+        axes_s[2].contourf(diff_smoothed, levels=levels_diff, cmap="RdBu_r", origin="upper")
+        axes_s[2].contour(diff_smoothed, levels=levels_diff, colors="k", linewidths=0.3, origin="upper")
+        _embryo_outline(mask_ref, axes_s[2], color="black", lw=1.5)
+        axes_s[2].set_title(f"Diff ({label_names[1]}−{label_names[0]}) σ={sigma}")
+        axes_s[2].axis("off")
+
+        fig_smooth.suptitle(f"Fig A4+: Smoothed Contours (σ={sigma})", fontsize=12)
+        fig_smooth.tight_layout(rect=[0, 0, 1, 0.95])
+        figs[f"cost_contour_sigma{sigma}"] = fig_smooth
+        if save_dir:
+            fig_smooth.savefig(save_dir / f"fig_A_cost_contour_sigma{sigma:.0f}.png",
+                               dpi=150, bbox_inches="tight")
+
+    return figs
+
+
+# ---------------------------------------------------------------------------
+# 3.2 Displacement dynamics maps
+# ---------------------------------------------------------------------------
+
+def plot_displacement_suite(
+    X: np.ndarray,
+    y: np.ndarray,
+    mask_ref: np.ndarray,
+    outlier_flag: np.ndarray,
+    stride: int = 8,
+    label_names: Dict[int, str] = None,
+    save_dir: Optional[str | Path] = None,
+) -> Dict[str, plt.Figure]:
+    """
+    Figs B1–B3: Mean displacement vector fields (quiver).
+    Requires V1_DYNAMICS channel set (ch1=disp_u, ch2=disp_v).
+    """
+    if label_names is None:
+        label_names = {0: "WT", 1: "cep290"}
+    if save_dir:
+        save_dir = Path(save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+    C = X.shape[-1]
+    if C < 3:
+        logger.warning("Displacement suite requires V1_DYNAMICS (C>=5), skipping")
+        return {}
+
+    valid = ~outlier_flag
+    X_valid = X[valid]
+    y_valid = y[valid]
+
+    # Compute mean displacement per class
+    mean_disp = {}
+    for label_int, label_str in label_names.items():
+        sel = y_valid == label_int
+        if sel.sum() > 0:
+            mean_u = np.mean(X_valid[sel, :, :, 1], axis=0)
+            mean_v = np.mean(X_valid[sel, :, :, 2], axis=0)
+        else:
+            mean_u = np.zeros_like(mask_ref, dtype=np.float32)
+            mean_v = np.zeros_like(mask_ref, dtype=np.float32)
+        mean_disp[label_str] = (mean_u, mean_v)
+
+    # Difference displacement
+    wt_name, mut_name = label_names[0], label_names[1]
+    diff_u = mean_disp[mut_name][0] - mean_disp[wt_name][0]
+    diff_v = mean_disp[mut_name][1] - mean_disp[wt_name][1]
+    mean_disp["Difference"] = (diff_u, diff_v)
+
+    figs = {}
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5))
+    mask_bool = mask_ref.astype(bool)
+
+    H, W = mask_ref.shape
+    yy, xx = np.meshgrid(np.arange(0, H, stride), np.arange(0, W, stride), indexing="ij")
+
+    for idx, (label, (u_map, v_map)) in enumerate(mean_disp.items()):
+        ax = axes[idx]
+
+        # Background: embryo mask
+        ax.imshow(mask_ref.astype(float), cmap="gray", alpha=0.3,
+                  extent=[0, W, H, 0], origin="upper")
+
+        # Quiver
+        u_sub = u_map[::stride, ::stride]
+        v_sub = v_map[::stride, ::stride]
+        mag_sub = np.sqrt(u_sub**2 + v_sub**2)
+
+        # Only plot where there's signal
+        threshold = np.percentile(mag_sub[mag_sub > 0], 10) if np.any(mag_sub > 0) else 0
+        show = mag_sub > threshold
+
+        if np.any(show):
+            ax.quiver(xx[show], yy[show], u_sub[show], v_sub[show],
+                      mag_sub[show], cmap="hot", scale=150, scale_units="xy",
+                      angles="xy", width=0.002)
+
+        _embryo_outline(mask_ref, ax, color="white")
+        ax.set_title(f"Fig B{idx+1}: {label}")
+        ax.axis("off")
+
+    fig.suptitle("Displacement Vector Fields (Mean)", fontsize=12)
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    figs["displacement_quiver"] = fig
+    if save_dir:
+        fig.savefig(save_dir / "fig_B1_B3_displacement_quiver.png", dpi=150, bbox_inches="tight")
+
+    # Optional: displacement magnitude maps
+    fig_mag, axes_m = plt.subplots(1, 3, figsize=(18, 5))
+    for idx, (label, (u_map, v_map)) in enumerate(mean_disp.items()):
+        ax = axes_m[idx]
+        mag = np.sqrt(u_map**2 + v_map**2)
+        display = _apply_mask_nan(mag, mask_ref)
+        im = ax.imshow(display, cmap="viridis", interpolation="bilinear")
+        _embryo_outline(mask_ref, ax)
+        ax.set_title(f"|d| — {label}")
+        ax.axis("off")
+        plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    fig_mag.suptitle("Displacement Magnitude", fontsize=12)
+    fig_mag.tight_layout(rect=[0, 0, 1, 0.95])
+    figs["displacement_magnitude"] = fig_mag
+    if save_dir:
+        fig_mag.savefig(save_dir / "fig_B_displacement_magnitude.png", dpi=150, bbox_inches="tight")
+
+    return figs
+
+
+# ---------------------------------------------------------------------------
+# AUROC per S-bin plots
+# ---------------------------------------------------------------------------
+
+def plot_auroc_vs_sbin(
+    auroc_dfs: Dict[str, pd.DataFrame],
+    K: int = 10,
+    title: str = "AUROC vs S-bin",
+    save_path: Optional[str | Path] = None,
+    bootstrap_result: Optional[Dict] = None,
+) -> plt.Figure:
+    """
+    Plot AUROC vs S-bin for one or more features.
+
+    auroc_dfs: dict mapping feature_name → DataFrame with k_bin, auroc columns
+    bootstrap_result: if provided, add confidence bands
+    """
+    fig, ax = plt.subplots(1, 1, figsize=(10, 5))
+
+    colors = plt.cm.Set1(np.linspace(0, 1, max(len(auroc_dfs), 1)))
+    s_centers = [(k + 0.5) / K for k in range(K)]
+
+    for i, (feat_name, df) in enumerate(auroc_dfs.items()):
+        df_sorted = df.sort_values("k_bin")
+        aurocs = df_sorted["auroc"].values
+        ax.plot(s_centers[:len(aurocs)], aurocs, "o-", color=colors[i],
+                label=feat_name, linewidth=2, markersize=6)
+
+    # Bootstrap confidence bands
+    if bootstrap_result is not None:
+        ci_lo = bootstrap_result.get("auroc_ci_lo")
+        ci_hi = bootstrap_result.get("auroc_ci_hi")
+        if ci_lo is not None and ci_hi is not None:
+            ax.fill_between(s_centers[:len(ci_lo)], ci_lo, ci_hi,
+                            alpha=0.2, color="gray", label="95% CI (bootstrap)")
+
+    ax.axhline(0.5, color="gray", linestyle="--", alpha=0.5, label="Chance")
+    ax.set_xlabel("S (rostral → caudal)")
+    ax.set_ylabel("AUROC")
+    ax.set_title(title)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0.3, 1.05)
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Logistic coefficient profile
+# ---------------------------------------------------------------------------
+
+def plot_coefficient_profile(
+    coef_mean: np.ndarray,
+    K: int = 10,
+    feature_cols: List[str] = ["cost_mean"],
+    title: str = "Logistic Regression Coefficients",
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """Plot coefficient magnitude profile over S-bins."""
+    fig, ax = plt.subplots(1, 1, figsize=(10, 5))
+
+    n_features = len(feature_cols)
+    s_centers = [(k + 0.5) / K for k in range(K)]
+
+    for j, feat_name in enumerate(feature_cols):
+        coefs = coef_mean[j * K:(j + 1) * K]
+        ax.bar([s + j * 0.03 for s in s_centers[:len(coefs)]], np.abs(coefs),
+               width=0.08, alpha=0.7, label=feat_name)
+
+    ax.set_xlabel("S (rostral → caudal)")
+    ax.set_ylabel("|coefficient|")
+    ax.set_title(title)
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Interval search visualization
+# ---------------------------------------------------------------------------
+
+def plot_interval_results(
+    interval_df: pd.DataFrame,
+    selected: Dict,
+    K: int = 10,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """Plot interval search results: AUROC vs interval, selected interval highlighted."""
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Left: best AUROC vs interval length
+    ax = axes[0]
+    best_by_len = interval_df.groupby("n_bins")["auroc"].max().reset_index()
+    ax.plot(best_by_len["n_bins"], best_by_len["auroc"], "o-", color="steelblue",
+            linewidth=2, markersize=8)
+    ax.axhline(selected["auroc"], color="red", linestyle="--", alpha=0.5)
+    ax.set_xlabel("Interval Length (bins)")
+    ax.set_ylabel("Best AUROC")
+    ax.set_title("Best AUROC vs Interval Length")
+    ax.grid(True, alpha=0.3)
+
+    # Right: selected interval on S axis
+    ax = axes[1]
+    s_centers = [(k + 0.5) / K for k in range(K)]
+    ax.bar(s_centers, [0.1] * K, width=1/K, color="lightgray", edgecolor="gray")
+
+    # Highlight selected interval
+    for k in range(selected["bin_start"], selected["bin_end"]):
+        ax.bar((k + 0.5) / K, 0.1, width=1/K, color="red", alpha=0.6)
+
+    ax.set_xlabel("S (rostral → caudal)")
+    ax.set_title(f"Selected Interval: S=[{selected['S_lo']:.2f}, {selected['S_hi']:.2f})\n"
+                 f"AUROC={selected['auroc']:.4f}, {selected['n_bins']} bins")
+    ax.set_xlim(0, 1)
+    ax.set_yticks([])
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Null distribution plots
+# ---------------------------------------------------------------------------
+
+def plot_permutation_null(
+    null_result: Dict,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """Histogram of permutation null distribution with observed value marked."""
+    fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+
+    null_dist = null_result["null_distribution"]
+    observed = null_result["observed"]
+    pvalue = null_result["pvalue"]
+
+    ax.hist(null_dist, bins=30, alpha=0.7, color="steelblue", edgecolor="k",
+            label="Null distribution")
+    ax.axvline(observed, color="red", linewidth=2, linestyle="--",
+               label=f"Observed={observed:.4f}\np={pvalue:.4f}")
+
+    ax.set_xlabel(f"AUROC ({null_result['statistic']})")
+    ax.set_ylabel("Count")
+    ax.set_title(f"Permutation Null ({null_result['test']})\n"
+                 f"n_perm={null_result['n_permute']}")
+    ax.legend(fontsize=9)
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    return fig
+
+
+def plot_bootstrap_interval_stability(
+    bootstrap_result: Dict,
+    K: int = 10,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """Plot bootstrap distributions of interval start/end points."""
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+
+    starts = bootstrap_result["interval_starts"]
+    ends = bootstrap_result["interval_ends"]
+
+    if len(starts) > 0:
+        axes[0].hist(starts / K, bins=K, alpha=0.7, color="steelblue", edgecolor="k")
+        axes[0].axvline(bootstrap_result["interval_start_mean"] / K, color="red", linewidth=2)
+    axes[0].set_xlabel("S start")
+    axes[0].set_title("Bootstrap: Interval Start Distribution")
+
+    if len(ends) > 0:
+        axes[1].hist(ends / K, bins=K, alpha=0.7, color="darkorange", edgecolor="k")
+        axes[1].axvline(bootstrap_result["interval_end_mean"] / K, color="red", linewidth=2)
+    axes[1].set_xlabel("S end")
+    axes[1].set_title("Bootstrap: Interval End Distribution")
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# S coordinate visualization
+# ---------------------------------------------------------------------------
+
+def plot_s_map(
+    S_map_ref: np.ndarray,
+    mask_ref: np.ndarray,
+    save_path: Optional[str | Path] = None,
+) -> plt.Figure:
+    """Plot the S coordinate map on the reference mask."""
+    fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+    display = _apply_mask_nan(S_map_ref, mask_ref)
+    im = ax.imshow(display, cmap="viridis", vmin=0, vmax=1, interpolation="bilinear")
+    _embryo_outline(mask_ref, ax, color="white")
+    plt.colorbar(im, ax=ax, label="S (0=head, 1=tail)")
+    ax.set_title("S Coordinate Map (Rostral → Caudal)")
+    ax.axis("off")
+
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    return fig
+
+
+__all__ = [
+    "plot_cost_density_suite",
+    "plot_displacement_suite",
+    "plot_auroc_vs_sbin",
+    "plot_coefficient_profile",
+    "plot_interval_results",
+    "plot_permutation_null",
+    "plot_bootstrap_interval_stability",
+    "plot_s_map",
+]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/run_phase0.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/run_phase0.py
@@ -1,0 +1,317 @@
+"""
+Phase 0 Orchestrator: Run the full Phase 0 pipeline.
+
+Follows the implementation order from PHASE0_SPEC.md:
+  0) FeatureDataset contract + validator
+  1) Generate OT maps
+  2) QC + filtering (GATE)
+  3) Compute S_map_ref
+  4) Build features_sbins.parquet
+  5) AUROC localization
+  6) Enable dynamics + rerun (if V1)
+  7) Interval search + sanity checks
+  8) Nulls + bootstrap stability
+
+Each step has a gate checkpoint. The orchestrator logs all
+intermediate results and creates a summary report.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from roi_config import Phase0RunConfig, Phase0FeatureSet
+
+logger = logging.getLogger(__name__)
+
+
+def run_phase0(
+    mask_ref: np.ndarray,
+    target_masks: List[np.ndarray],
+    y: np.ndarray,
+    metadata_df: pd.DataFrame,
+    config: Phase0RunConfig = Phase0RunConfig(),
+    uot_config=None,
+    backend=None,
+) -> Dict:
+    """
+    Run the full Phase 0 pipeline.
+
+    Parameters
+    ----------
+    mask_ref : (512, 512) uint8 — fixed WT reference mask
+    target_masks : list of (512, 512) uint8 — all WT + cep290 target masks
+    y : (N,) int — labels (0=WT, 1=cep290)
+    metadata_df : DataFrame with sample_id, embryo_id, snip_id columns
+    config : Phase0RunConfig
+    uot_config : UOTConfig, optional
+    backend : UOTBackend, optional
+
+    Returns
+    -------
+    dict with all intermediate results and gate statuses.
+    """
+    out_dir = Path(config.out_dir or f"results/phase0_{config.genotype}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {"config": config, "out_dir": str(out_dir), "gates": {}}
+    N = len(target_masks)
+    sample_ids = metadata_df.get("sample_id", pd.Series([f"s_{i}" for i in range(N)])).tolist()
+
+    # =====================================================================
+    # Step 1: Generate OT maps
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 1: Generate OT maps")
+    logger.info("=" * 60)
+
+    from p0_ot_maps import generate_ot_maps
+    X, total_cost_C = generate_ot_maps(
+        mask_ref, target_masks, sample_ids,
+        feature_set=config.feature_set,
+        uot_config=uot_config, backend=backend,
+    )
+    results["X_shape"] = X.shape
+    results["total_cost_mean"] = float(total_cost_C.mean())
+
+    # =====================================================================
+    # Step 2: QC + Filtering (GATE)
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 2: QC + Filtering")
+    logger.info("=" * 60)
+
+    from p0_qc import run_qc_suite
+    qc_dir = out_dir / "qc"
+    outlier_flag, qc_stats = run_qc_suite(
+        X, y, total_cost_C, mask_ref, metadata_df, sample_ids,
+        out_dir=qc_dir,
+        iqr_multiplier=config.dataset.iqr_multiplier,
+    )
+    results["qc_stats"] = qc_stats
+    results["gates"]["qc_passed"] = True  # User must visually confirm
+
+    # =====================================================================
+    # Step 3: Visualizations (cost density + optionally displacement)
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 3: Visualizations")
+    logger.info("=" * 60)
+
+    from p0_viz import plot_cost_density_suite, plot_displacement_suite
+    viz_dir = out_dir / "viz"
+
+    plot_cost_density_suite(
+        X, y, mask_ref, outlier_flag,
+        sigma_grid=config.viz_sigma_grid,
+        save_dir=viz_dir,
+    )
+
+    if config.feature_set == Phase0FeatureSet.V1_DYNAMICS:
+        plot_displacement_suite(
+            X, y, mask_ref, outlier_flag,
+            stride=config.quiver_stride,
+            save_dir=viz_dir,
+        )
+
+    # =====================================================================
+    # Step 4: S coordinate
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 4: S coordinate")
+    logger.info("=" * 60)
+
+    from p0_s_coordinate import build_s_coordinate
+    from p0_viz import plot_s_map
+
+    S_map_ref, tangent_ref, normal_ref, s_info = build_s_coordinate(
+        mask_ref, config=config.s_coord,
+    )
+    results["s_coordinate_info"] = s_info
+
+    plot_s_map(S_map_ref, mask_ref, save_path=viz_dir / "s_map_ref.png")
+
+    # =====================================================================
+    # Step 5: Build FeatureDataset + S-bin features
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 5: Build S-bin feature table")
+    logger.info("=" * 60)
+
+    from roi_feature_dataset import Phase0FeatureDatasetBuilder
+    dataset_dir = out_dir / "feature_dataset"
+    builder = Phase0FeatureDatasetBuilder(
+        out_dir=dataset_dir,
+        feature_set=config.feature_set,
+        config=config.dataset,
+        stage_window=config.stage_window,
+    )
+    builder.build(
+        X=X, y=y, mask_ref=mask_ref, metadata_df=metadata_df,
+        total_cost_C=total_cost_C,
+        S_map_ref=S_map_ref, tangent_ref=tangent_ref, normal_ref=normal_ref,
+    )
+
+    from p0_sbin_features import build_sbin_features
+    K = config.s_bins.K
+    sbin_path = out_dir / "features_sbins.parquet"
+    sbin_df = build_sbin_features(
+        X, y, S_map_ref, metadata_df, outlier_flag,
+        feature_set=config.feature_set, K=K,
+        tangent_ref=tangent_ref, normal_ref=normal_ref,
+        save_path=sbin_path,
+    )
+    results["sbin_shape"] = sbin_df.shape
+
+    # =====================================================================
+    # Step 6: AUROC localization + logistic
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 6: Classification + AUROC")
+    logger.info("=" * 60)
+
+    from p0_classification import run_phase0_classification, compute_auroc_per_bin
+    from p0_viz import plot_auroc_vs_sbin, plot_coefficient_profile
+
+    class_results = run_phase0_classification(sbin_df, n_folds=config.classification.n_cv_folds)
+    results["classification"] = {
+        k: v for k, v in class_results.items()
+        if not isinstance(v, pd.DataFrame)
+    }
+
+    # Plot AUROC per bin
+    auroc_dfs = {}
+    for key, val in class_results.items():
+        if isinstance(val, pd.DataFrame) and "auroc" in val.columns:
+            auroc_dfs[key] = val
+
+    if auroc_dfs:
+        plot_auroc_vs_sbin(auroc_dfs, K=K, save_path=viz_dir / "auroc_vs_sbin.png")
+
+    # Plot coefficient profile
+    logistic_cost = class_results.get("logistic_cost_filtered", {})
+    if isinstance(logistic_cost, dict) and "coef_mean" in logistic_cost:
+        plot_coefficient_profile(
+            logistic_cost["coef_mean"], K=K,
+            save_path=viz_dir / "logistic_coef_profile.png",
+        )
+
+    # =====================================================================
+    # Step 7: Interval search + sanity checks
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 7: Interval search")
+    logger.info("=" * 60)
+
+    from p0_interval_search import search_all_intervals, select_best_interval, run_sanity_checks
+    from p0_viz import plot_interval_results
+
+    interval_df = search_all_intervals(
+        sbin_df, feature_cols=["cost_mean"], K=K,
+        n_folds=config.classification.n_cv_folds,
+    )
+    interval_df.to_csv(out_dir / "interval_search.csv", index=False)
+
+    selected = select_best_interval(interval_df, config.interval, K=K)
+    results["selected_interval"] = selected
+
+    sanity = run_sanity_checks(
+        sbin_df, selected, feature_cols=["cost_mean"],
+        n_folds=config.classification.n_cv_folds, K=K,
+    )
+    results["sanity_checks"] = sanity
+
+    plot_interval_results(interval_df, selected, K=K,
+                          save_path=viz_dir / "interval_search_results.png")
+
+    # =====================================================================
+    # Step 8: Nulls + bootstrap stability
+    # =====================================================================
+    logger.info("=" * 60)
+    logger.info("PHASE 0 STEP 8: Nulls + Stability")
+    logger.info("=" * 60)
+
+    from p0_nulls import run_permutation_null_auroc_max, run_permutation_null_interval, run_bootstrap_stability
+    from p0_viz import plot_permutation_null, plot_bootstrap_interval_stability
+
+    # Observed max AUROC
+    auroc_cost_df = compute_auroc_per_bin(sbin_df, "cost_mean", exclude_outliers=True)
+    observed_max = float(auroc_cost_df["auroc"].max())
+
+    # 8.1 Permutation nulls
+    perm_auroc = run_permutation_null_auroc_max(
+        sbin_df, observed_max,
+        n_permute=config.nulls.n_permute,
+        random_seed=config.nulls.random_seed,
+    )
+    results["perm_null_auroc"] = {
+        k: v for k, v in perm_auroc.items() if k != "null_distribution"
+    }
+    plot_permutation_null(perm_auroc, save_path=viz_dir / "perm_null_auroc.png")
+
+    perm_interval = run_permutation_null_interval(
+        sbin_df, selected["auroc"],
+        K=K, n_folds=config.classification.n_cv_folds,
+        n_permute=min(config.nulls.n_permute, 50),  # Interval search is expensive
+        random_seed=config.nulls.random_seed,
+    )
+    results["perm_null_interval"] = {
+        k: v for k, v in perm_interval.items() if k != "null_distribution"
+    }
+    plot_permutation_null(perm_interval, save_path=viz_dir / "perm_null_interval.png")
+
+    # 8.2 Bootstrap stability
+    boot = run_bootstrap_stability(
+        sbin_df, K=K, n_folds=config.classification.n_cv_folds,
+        n_boot=config.nulls.n_boot,
+        random_seed=config.nulls.random_seed,
+    )
+    results["bootstrap"] = {
+        k: v for k, v in boot.items()
+        if not isinstance(v, np.ndarray) or v.ndim == 0
+    }
+
+    # Re-plot AUROC with bootstrap CIs
+    plot_auroc_vs_sbin(
+        {"cost_mean": auroc_cost_df}, K=K,
+        bootstrap_result=boot,
+        save_path=viz_dir / "auroc_vs_sbin_with_ci.png",
+    )
+    plot_bootstrap_interval_stability(boot, K=K, save_path=viz_dir / "bootstrap_interval.png")
+
+    # =====================================================================
+    # Save summary
+    # =====================================================================
+    summary_path = out_dir / "phase0_summary.json"
+    # Filter to JSON-serializable values
+    summary = {}
+    for k, v in results.items():
+        if isinstance(v, (str, int, float, bool, list, dict)):
+            try:
+                json.dumps(v)
+                summary[k] = v
+            except (TypeError, ValueError):
+                summary[k] = str(v)
+        elif isinstance(v, tuple):
+            summary[k] = list(v)
+
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2, default=str)
+
+    logger.info(f"Phase 0 complete. Results in: {out_dir}")
+    plt.close("all")
+
+    return results
+
+
+__all__ = ["run_phase0"]

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/TESTPLAN.md
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/TESTPLAN.md
@@ -1,0 +1,96 @@
+# ROI Discovery Test Plan — Phases 1 through 2.5
+
+**Date:** 2026-02-16
+**Status:** Draft — execute sequentially; each task has its own test file.
+
+## How to use this plan
+
+Each task below maps to a test file in this `tests/` directory. Run them in order.
+Files are structured as standalone pytest modules with synthetic data fixtures.
+No real data or GPU required — all tests use tiny grids (16x16 or 32x32) and NumPy fallbacks where possible.
+
+**Key biological prior (cep290):** The cep290 mutant phenotype produces signal
+predominantly in the **tail region** of the embryo. Planted-ROI tests embed signal
+in the bottom rows of the grid to simulate this. Sanity checks verify that
+discovered ROIs concentrate there, not at the head/top.
+
+---
+
+## Phase 1: Core Pipeline
+
+| # | Task | Test File | What it checks |
+|---|------|-----------|----------------|
+| 1.1 | Config construction + validation | `test_p1_01_config.py` | Enums, presets, frozen dataclasses, resolve_lambda/mu |
+| 1.2 | FeatureDataset build + validate | `test_p1_02_feature_dataset.py` | Zarr/Parquet round-trip, manifest schema, QC outlier flagging |
+| 1.3 | Loader + CV splits | `test_p1_03_loader.py` | Group-aware splits, no embryo leakage, class weights fold-local |
+| 1.4 | TV edge construction + computation | `test_p1_04_tv.py` | Edge list correctness, mask-aware boundaries, boundary fraction |
+| 1.5 | Trainer (logistic + L1 + TV) | `test_p1_05_trainer.py` | Convergence on planted signal, weight map localization, objective logging |
+| 1.6 | ROI extraction | `test_p1_06_roi_extraction.py` | Quantile thresholding, area_fraction, n_components, tail concentration |
+| 1.7 | Lambda/mu sweep + selection | `test_p1_07_sweep.py` | Pareto knee, epsilon-best, sweep table completeness, determinism |
+| 1.8 | Permutation null (NULL 1) | `test_p1_08_null_permutation.py` | Selection-aware p-value, null AUROC distribution, embryo-level shuffle |
+| 1.9 | Bootstrap stability (NULL 3) | `test_p1_09_null_bootstrap.py` | IoU distribution, fixed-(lam,mu), group-aware resampling |
+| 1.10 | API integration (fit/plot/report) | `test_p1_10_api.py` | End-to-end smoke test through roi_api.fit() |
+
+## Phase 2.0: Occlusion Validation
+
+| # | Task | Test File | What it checks |
+|---|------|-----------|----------------|
+| 2.1 | Perturbation + baseline | `test_p2_01_perturbation.py` | Spatial baseline from WT only, preserve/delete operator shapes, fold safety |
+| 2.2 | Occlusion evaluation | `test_p2_02_occlusion_eval.py` | Logit gaps, AUROC deltas, single-class NaN handling |
+| 2.3 | Bootstrap occlusion (OOB) | `test_p2_03_occlusion_bootstrap.py` | OOB-only evaluation, degenerate OOB handling, threshold sensitivity |
+| 2.4 | Resampling helpers | `test_p2_04_resampling.py` | iter_bootstrap_groups, stratification, OOB empty/single-class flags |
+| 2.5 | Integration fixes (ADDENDUM A) | `test_p2_05_integration_fixes.py` | compute_logits shared utility, channel_names in TrainResult, config import |
+
+## Phase 2.5: Learned Mask (Fixed Model)
+
+| # | Task | Test File | What it checks |
+|---|------|-----------|----------------|
+| 2.5.1 | Mask parameterization | `test_p25_01_mask_param.py` | sigmoid conversion, upsample, TV loss, jitter shift |
+| 2.5.2 | Mask objective (dual) | `test_p25_02_mask_objective.py` | Preserve > delete on planted ROI, score monotonicity |
+| 2.5.3 | Mask trainer (fixed model) | `test_p25_03_mask_trainer.py` | Mask recovers planted ROI, objective decreases, jitter stability |
+
+---
+
+## Execution checklist
+
+```
+Phase 1:
+  [ ] 1.1  Config
+  [ ] 1.2  FeatureDataset
+  [ ] 1.3  Loader
+  [ ] 1.4  TV
+  [ ] 1.5  Trainer
+  [ ] 1.6  ROI extraction
+  [ ] 1.7  Sweep
+  [ ] 1.8  Permutation null
+  [ ] 1.9  Bootstrap stability
+  [ ] 1.10 API integration
+
+Phase 2.0:
+  [ ] 2.1  Perturbation + baseline
+  [ ] 2.2  Occlusion evaluation
+  [ ] 2.3  Bootstrap occlusion
+  [ ] 2.4  Resampling helpers
+  [ ] 2.5  Integration fixes
+
+Phase 2.5:
+  [ ] 2.5.1  Mask parameterization
+  [ ] 2.5.2  Mask objective
+  [ ] 2.5.3  Mask trainer
+```
+
+## Running
+
+```bash
+# From the roi_discovery directory:
+cd results/mcolon/20260215_roi_discovery_via_ot_feature_maps
+
+# Run all tests:
+pytest tests/ -v
+
+# Run a single phase:
+pytest tests/test_p1_*.py -v
+
+# Run a single task:
+pytest tests/test_p1_04_tv.py -v
+```

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/conftest.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/conftest.py
@@ -1,0 +1,110 @@
+"""
+Shared fixtures for ROI discovery test suite.
+
+All fixtures use tiny grids (16x16 or 32x32) with 1-2 channels so tests
+run fast on CPU without real data.
+
+Biological prior: cep290 signal is planted in the BOTTOM rows ("tail")
+of the grid. WT samples have uniform/random noise everywhere.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Make the parent ROI discovery module importable
+ROI_DIR = Path(__file__).resolve().parent.parent
+if str(ROI_DIR) not in sys.path:
+    sys.path.insert(0, str(ROI_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Grid / mask helpers
+# ---------------------------------------------------------------------------
+
+GRID_H, GRID_W = 32, 32
+N_CHANNELS = 1
+N_WT = 10
+N_MUT = 10
+N_TOTAL = N_WT + N_MUT
+TAIL_START_ROW = 22  # bottom ~30% of the 32-row grid = "tail"
+
+
+@pytest.fixture
+def mask_ref():
+    """A simple elliptical embryo mask on a 32x32 grid."""
+    m = np.zeros((GRID_H, GRID_W), dtype=bool)
+    cy, cx = GRID_H // 2, GRID_W // 2
+    ry, rx = GRID_H // 2 - 2, GRID_W // 2 - 2
+    for i in range(GRID_H):
+        for j in range(GRID_W):
+            if ((i - cy) / ry) ** 2 + ((j - cx) / rx) ** 2 <= 1.0:
+                m[i, j] = True
+    return m
+
+
+@pytest.fixture
+def tail_roi_mask(mask_ref):
+    """Ground-truth ROI: bottom rows inside the embryo mask (tail region)."""
+    roi = np.zeros_like(mask_ref)
+    roi[TAIL_START_ROW:, :] = True
+    roi = roi & mask_ref
+    return roi
+
+
+@pytest.fixture
+def planted_data(mask_ref, tail_roi_mask):
+    """
+    Synthetic dataset with signal planted in the tail.
+
+    WT (y=0): uniform low noise everywhere.
+    MUT (y=1): same low noise + a positive bump in the tail ROI.
+
+    This mimics the cep290 phenotype where OT cost maps show
+    elevated signal in the tail.
+    """
+    rng = np.random.default_rng(42)
+
+    X = rng.normal(0.0, 0.1, size=(N_TOTAL, GRID_H, GRID_W, N_CHANNELS)).astype(np.float32)
+    y = np.array([0] * N_WT + [1] * N_MUT, dtype=np.int32)
+    groups = np.arange(N_TOTAL)  # each sample is its own embryo
+
+    # Plant signal in tail for mutants only
+    signal_strength = 2.0
+    for i in range(N_WT, N_TOTAL):
+        X[i][tail_roi_mask, :] += signal_strength
+
+    # Zero out anything outside the embryo mask
+    X[:, ~mask_ref, :] = 0.0
+
+    return {
+        "X": X,
+        "y": y,
+        "groups": groups,
+        "mask_ref": mask_ref,
+        "tail_roi": tail_roi_mask,
+        "channel_names": ("total_cost",),
+    }
+
+
+@pytest.fixture
+def class_weights():
+    """Balanced class weights for equal-sized WT/MUT groups."""
+    return {0: 1.0, 1: 1.0}
+
+
+@pytest.fixture
+def tiny_trainer_config():
+    """Fast trainer config for tests: small grid, few steps."""
+    from roi_config import TrainerConfig
+    return TrainerConfig(
+        learn_res=16,
+        output_res=GRID_H,
+        learning_rate=1e-2,
+        max_steps=100,
+        convergence_tol=1e-8,
+        log_every=10,
+        random_seed=42,
+    )

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_01_config.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_01_config.py
@@ -1,0 +1,147 @@
+"""
+Phase 1 / Task 1.1 — Configuration construction and validation.
+
+Checks:
+- All enums have expected members
+- Frozen dataclasses reject mutation
+- LAMBDA_PRESETS and MU_PRESETS are non-empty and sorted
+- ROIRunConfig.resolve_lambda_values / resolve_mu_values return correct presets
+- Default SweepConfig has sensible ranges
+"""
+
+import pytest
+from roi_config import (
+    CHANNEL_SCHEMAS,
+    LAMBDA_PRESETS,
+    MU_PRESETS,
+    ChannelSchema,
+    FeatureDatasetConfig,
+    FeatureSet,
+    NullConfig,
+    NullMode,
+    ROIRunConfig,
+    ROISizePreset,
+    SelectionRule,
+    SmoothnessPreset,
+    SweepConfig,
+    TrainerConfig,
+)
+
+
+# ---- Enum completeness ----
+
+def test_feature_set_members():
+    assert set(FeatureSet) == {FeatureSet.COST, FeatureSet.COST_DISP, FeatureSet.ALL_OT}
+
+
+def test_roi_size_preset_members():
+    assert set(ROISizePreset) == {ROISizePreset.SMALL, ROISizePreset.MEDIUM, ROISizePreset.LARGE}
+
+
+def test_smoothness_preset_members():
+    assert set(SmoothnessPreset) == {SmoothnessPreset.LOW, SmoothnessPreset.MEDIUM, SmoothnessPreset.HIGH}
+
+
+def test_null_mode_members():
+    assert set(NullMode) == {NullMode.PERMUTE, NullMode.BOOTSTRAP, NullMode.BOTH, NullMode.NONE}
+
+
+def test_selection_rule_members():
+    assert set(SelectionRule) == {SelectionRule.PARETO_KNEE, SelectionRule.EPSILON_BEST}
+
+
+# ---- Presets are non-empty ----
+
+def test_lambda_presets_coverage():
+    for preset in ROISizePreset:
+        vals = LAMBDA_PRESETS[preset]
+        assert len(vals) >= 2, f"LAMBDA_PRESETS[{preset}] too short"
+        assert all(v > 0 for v in vals), "All lambda values must be positive"
+
+
+def test_mu_presets_coverage():
+    for preset in SmoothnessPreset:
+        vals = MU_PRESETS[preset]
+        assert len(vals) >= 2, f"MU_PRESETS[{preset}] too short"
+        assert all(v > 0 for v in vals), "All mu values must be positive"
+
+
+# ---- Channel schemas ----
+
+def test_channel_schemas_all_feature_sets():
+    for fs in FeatureSet:
+        schemas = CHANNEL_SCHEMAS[fs]
+        assert len(schemas) >= 1
+        assert all(isinstance(s, ChannelSchema) for s in schemas)
+
+
+def test_cost_has_one_channel():
+    assert len(CHANNEL_SCHEMAS[FeatureSet.COST]) == 1
+    assert CHANNEL_SCHEMAS[FeatureSet.COST][0].name == "total_cost"
+
+
+def test_all_ot_has_five_channels():
+    assert len(CHANNEL_SCHEMAS[FeatureSet.ALL_OT]) == 5
+
+
+# ---- Frozen dataclass enforcement ----
+
+def test_feature_dataset_config_frozen():
+    cfg = FeatureDatasetConfig()
+    with pytest.raises(Exception):  # FrozenInstanceError
+        cfg.canonical_grid_hw = (256, 256)
+
+
+def test_trainer_config_frozen():
+    cfg = TrainerConfig()
+    with pytest.raises(Exception):
+        cfg.learn_res = 256
+
+
+def test_sweep_config_frozen():
+    cfg = SweepConfig()
+    with pytest.raises(Exception):
+        cfg.n_cv_folds = 3
+
+
+# ---- Defaults ----
+
+def test_feature_dataset_defaults():
+    cfg = FeatureDatasetConfig()
+    assert cfg.canonical_grid_hw == (512, 512)
+    assert cfg.group_key == "embryo_id"
+    assert cfg.iqr_multiplier == 1.5
+
+
+def test_trainer_defaults():
+    cfg = TrainerConfig()
+    assert cfg.learn_res == 128
+    assert cfg.output_res == 512
+    assert cfg.max_steps >= 1000
+
+
+def test_sweep_config_defaults():
+    cfg = SweepConfig()
+    assert cfg.n_cv_folds == 5
+    assert cfg.selection_rule == SelectionRule.PARETO_KNEE
+    assert 0.0 < cfg.roi_quantile < 1.0
+
+
+# ---- ROIRunConfig resolution ----
+
+def test_resolve_lambda_values_medium():
+    rc = ROIRunConfig(roi_size=ROISizePreset.MEDIUM)
+    vals = rc.resolve_lambda_values()
+    assert vals == list(LAMBDA_PRESETS[ROISizePreset.MEDIUM])
+
+
+def test_resolve_mu_values_high():
+    rc = ROIRunConfig(smoothness=SmoothnessPreset.HIGH)
+    vals = rc.resolve_mu_values()
+    assert vals == list(MU_PRESETS[SmoothnessPreset.HIGH])
+
+
+def test_roi_run_config_default_genotype():
+    rc = ROIRunConfig()
+    assert rc.genotype == "cep290"
+    assert rc.reference == "WT"

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_02_feature_dataset.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_02_feature_dataset.py
@@ -1,0 +1,149 @@
+"""
+Phase 1 / Task 1.2 — FeatureDataset builder and validator.
+
+Checks:
+- Builder creates Zarr arrays, Parquet metadata, and JSON manifest
+- Manifest contains required keys (canonical_grid, channel_schema, QC rules, etc.)
+- Validator rejects datasets with missing arrays or wrong shapes
+- QC outlier flagging works with IQR rule
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Optional: only run if zarr is installed
+zarr = pytest.importorskip("zarr")
+pd = pytest.importorskip("pandas")
+
+from roi_config import CHANNEL_SCHEMAS, FeatureDatasetConfig, FeatureSet
+from roi_feature_dataset import FeatureDatasetBuilder, validate_feature_dataset
+
+
+@pytest.fixture
+def tmp_dataset_dir(tmp_path):
+    return tmp_path / "roi_feature_dataset_test"
+
+
+@pytest.fixture
+def small_dataset_arrays():
+    """Minimal arrays for building a FeatureDataset."""
+    N, H, W, C = 8, 512, 512, 1
+    rng = np.random.default_rng(99)
+    X = rng.normal(0, 1, (N, H, W, C)).astype(np.float32)
+    y = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int32)
+    mask_ref = np.ones((H, W), dtype=bool)
+    total_cost_C = rng.uniform(0.5, 1.5, N).astype(np.float32)
+    metadata = pd.DataFrame({
+        "embryo_id": [f"emb_{i}" for i in range(N)],
+        "genotype": ["WT"] * 4 + ["cep290"] * 4,
+        "label": y,
+    })
+    return {
+        "X": X, "y": y, "mask_ref": mask_ref,
+        "total_cost_C": total_cost_C, "metadata": metadata,
+    }
+
+
+# ---- Builder creates expected structure ----
+
+def test_builder_creates_zarr_and_manifest(tmp_dataset_dir, small_dataset_arrays):
+    """
+    PSEUDO-LOGIC:
+    1. Instantiate FeatureDatasetBuilder with default config
+    2. Call build() with synthetic arrays
+    3. Assert manifest.json, metadata.parquet, and features.zarr/ all exist
+    4. Assert Zarr groups X, y, mask_ref, qc/ are present
+    """
+    builder = FeatureDatasetBuilder(
+        config=FeatureDatasetConfig(),
+        feature_set=FeatureSet.COST,
+    )
+    builder.build(
+        out_dir=str(tmp_dataset_dir),
+        X=small_dataset_arrays["X"],
+        y=small_dataset_arrays["y"],
+        mask_ref=small_dataset_arrays["mask_ref"],
+        total_cost_C=small_dataset_arrays["total_cost_C"],
+        metadata=small_dataset_arrays["metadata"],
+    )
+
+    assert (tmp_dataset_dir / "manifest.json").exists()
+    assert (tmp_dataset_dir / "metadata.parquet").exists()
+    assert (tmp_dataset_dir / "features.zarr").exists()
+
+
+def test_manifest_required_keys(tmp_dataset_dir, small_dataset_arrays):
+    """Manifest must contain canonical_grid, channel_schema, qc_rules, split_policy."""
+    builder = FeatureDatasetBuilder(
+        config=FeatureDatasetConfig(),
+        feature_set=FeatureSet.COST,
+    )
+    builder.build(
+        out_dir=str(tmp_dataset_dir),
+        X=small_dataset_arrays["X"],
+        y=small_dataset_arrays["y"],
+        mask_ref=small_dataset_arrays["mask_ref"],
+        total_cost_C=small_dataset_arrays["total_cost_C"],
+        metadata=small_dataset_arrays["metadata"],
+    )
+
+    with open(tmp_dataset_dir / "manifest.json") as f:
+        manifest = json.load(f)
+
+    required_keys = ["canonical_grid", "channel_schema", "qc_rules", "split_policy"]
+    for key in required_keys:
+        assert key in manifest, f"Missing required manifest key: {key}"
+
+
+# ---- Validator catches bad datasets ----
+
+def test_validate_rejects_missing_zarr(tmp_path):
+    """
+    PSEUDO-LOGIC:
+    1. Create a directory with manifest.json but no features.zarr
+    2. Call validate_feature_dataset()
+    3. Expect DatasetValidationError
+    """
+    d = tmp_path / "bad_dataset"
+    d.mkdir()
+    (d / "manifest.json").write_text("{}")
+    # No features.zarr — should fail
+    with pytest.raises(Exception):
+        validate_feature_dataset(str(d))
+
+
+# ---- QC outlier flagging ----
+
+def test_qc_outlier_flagging_iqr(tmp_dataset_dir, small_dataset_arrays):
+    """
+    PSEUDO-LOGIC:
+    1. Inject one extreme outlier into total_cost_C
+    2. Build dataset
+    3. Check qc/outlier_flag array has exactly one True
+    """
+    arrays = small_dataset_arrays.copy()
+    arrays["total_cost_C"] = arrays["total_cost_C"].copy()
+    arrays["total_cost_C"][0] = 100.0  # extreme outlier
+
+    builder = FeatureDatasetBuilder(
+        config=FeatureDatasetConfig(iqr_multiplier=1.5),
+        feature_set=FeatureSet.COST,
+    )
+    builder.build(
+        out_dir=str(tmp_dataset_dir),
+        X=arrays["X"],
+        y=arrays["y"],
+        mask_ref=arrays["mask_ref"],
+        total_cost_C=arrays["total_cost_C"],
+        metadata=arrays["metadata"],
+    )
+
+    z = zarr.open(str(tmp_dataset_dir / "features.zarr"), "r")
+    if "qc" in z and "outlier_flag" in z["qc"]:
+        flags = np.array(z["qc"]["outlier_flag"])
+        assert flags[0] == True, "Extreme outlier should be flagged"
+        assert flags.sum() >= 1

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_03_loader.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_03_loader.py
@@ -1,0 +1,93 @@
+"""
+Phase 1 / Task 1.3 — Loader and CV split generation.
+
+Checks:
+- GroupKFold splits never leak embryo_id across train/val
+- Class weights are computed from training fold only
+- All samples in each group share the same label
+"""
+
+import numpy as np
+import pytest
+
+from conftest import N_MUT, N_TOTAL, N_WT
+
+
+# ---- Group-aware CV: no embryo leakage ----
+
+def test_no_embryo_leakage_in_cv(planted_data):
+    """
+    PSEUDO-LOGIC:
+    1. Create GroupKFold splits using embryo_id as group key
+    2. For each fold, verify train_groups ∩ val_groups = ∅
+    3. This is the MANDATORY anti-leakage check from PLAN.md Section A
+    """
+    from sklearn.model_selection import GroupKFold
+
+    X = planted_data["X"]
+    y = planted_data["y"]
+    groups = planted_data["groups"]
+
+    gkf = GroupKFold(n_splits=5)
+    for fold_i, (train_idx, val_idx) in enumerate(gkf.split(X, y, groups)):
+        train_groups = set(groups[train_idx])
+        val_groups = set(groups[val_idx])
+        overlap = train_groups & val_groups
+        assert len(overlap) == 0, (
+            f"Fold {fold_i}: embryo leakage detected! "
+            f"Groups in both train and val: {overlap}"
+        )
+
+
+def test_all_samples_in_group_share_label(planted_data):
+    """Every sample from the same embryo must have the same class label."""
+    y = planted_data["y"]
+    groups = planted_data["groups"]
+
+    for g in np.unique(groups):
+        labels = np.unique(y[groups == g])
+        assert len(labels) == 1, f"Group {g} has mixed labels: {labels}"
+
+
+def test_fold_local_class_weights(planted_data):
+    """
+    PSEUDO-LOGIC:
+    1. Create a GroupKFold split
+    2. Compute class weights from TRAINING fold only
+    3. Verify weights differ from global weights when class balance changes per fold
+    """
+    from sklearn.model_selection import GroupKFold
+    from sklearn.utils.class_weight import compute_class_weight
+
+    X = planted_data["X"]
+    y = planted_data["y"]
+    groups = planted_data["groups"]
+
+    gkf = GroupKFold(n_splits=5)
+    for train_idx, val_idx in gkf.split(X, y, groups):
+        y_train = y[train_idx]
+        classes = np.unique(y_train)
+        if len(classes) < 2:
+            continue  # degenerate fold
+        weights = compute_class_weight("balanced", classes=classes, y=y_train)
+        cw = {int(c): float(w) for c, w in zip(classes, weights)}
+
+        # Weights should be positive and reasonable
+        for c in classes:
+            assert cw[int(c)] > 0, f"Class weight for class {c} is non-positive"
+
+
+def test_cv_covers_all_samples(planted_data):
+    """Every sample appears in exactly one validation fold."""
+    from sklearn.model_selection import GroupKFold
+
+    X = planted_data["X"]
+    y = planted_data["y"]
+    groups = planted_data["groups"]
+
+    gkf = GroupKFold(n_splits=5)
+    all_val = set()
+    for _, val_idx in gkf.split(X, y, groups):
+        all_val.update(val_idx)
+
+    assert all_val == set(range(len(y))), "Not all samples covered by CV folds"

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_04_tv.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_04_tv.py
@@ -1,0 +1,127 @@
+"""
+Phase 1 / Task 1.4 — Total Variation edge construction and computation.
+
+Checks:
+- Edge list only contains edges where BOTH endpoints are inside mask
+- No edges cross the mask boundary
+- A constant weight map has TV = 0
+- A weight map with a single sharp step has predictable TV
+- Boundary fraction detects ROI at the mask edge vs interior
+"""
+
+import numpy as np
+import pytest
+
+from roi_tv import build_tv_edges, compute_boundary_fraction, compute_tv_numpy
+
+
+# ---- Edge construction ----
+
+def test_edges_only_inside_mask(mask_ref):
+    """Every edge (src, tgt) must have both endpoints inside the mask."""
+    edges_src, edges_tgt = build_tv_edges(mask_ref)
+    H, W = mask_ref.shape
+    flat_mask = mask_ref.ravel()
+
+    assert np.all(flat_mask[edges_src]), "Some edge sources are outside mask"
+    assert np.all(flat_mask[edges_tgt]), "Some edge targets are outside mask"
+
+
+def test_no_edges_on_empty_mask():
+    """A fully-False mask should produce zero edges."""
+    mask = np.zeros((16, 16), dtype=bool)
+    src, tgt = build_tv_edges(mask)
+    assert len(src) == 0
+    assert len(tgt) == 0
+
+
+def test_full_mask_edge_count():
+    """A fully-True HxW mask should have (H-1)*W + H*(W-1) horizontal+vertical edges."""
+    H, W = 8, 8
+    mask = np.ones((H, W), dtype=bool)
+    src, tgt = build_tv_edges(mask)
+    expected = (H - 1) * W + H * (W - 1)
+    assert len(src) == expected, f"Expected {expected} edges, got {len(src)}"
+
+
+def test_edges_are_4_neighborhood(mask_ref):
+    """Each edge should connect adjacent pixels (Manhattan distance = 1)."""
+    edges_src, edges_tgt = build_tv_edges(mask_ref)
+    H, W = mask_ref.shape
+
+    src_r, src_c = np.divmod(edges_src, W)
+    tgt_r, tgt_c = np.divmod(edges_tgt, W)
+
+    manhattan = np.abs(src_r - tgt_r) + np.abs(src_c - tgt_c)
+    assert np.all(manhattan == 1), "Found edges with Manhattan distance != 1"
+
+
+# ---- TV computation ----
+
+def test_constant_map_has_zero_tv(mask_ref):
+    """A spatially constant weight map should have TV = 0."""
+    w = np.ones((mask_ref.shape[0], mask_ref.shape[1]), dtype=np.float32) * 3.14
+    tv = compute_tv_numpy(w, mask_ref)
+    assert tv == pytest.approx(0.0, abs=1e-6)
+
+
+def test_step_function_tv():
+    """
+    A step function on a full 4x4 mask with a horizontal edge between
+    rows 1 and 2 should have TV = 4 * |step_height| (one edge per column).
+    """
+    mask = np.ones((4, 4), dtype=bool)
+    w = np.zeros((4, 4), dtype=np.float32)
+    w[2:, :] = 5.0  # step of height 5 between row 1 and 2
+
+    tv = compute_tv_numpy(w, mask)
+    # Horizontal edges crossing the step: 4 columns * |5| = 20
+    # Plus no vertical steps within top or bottom blocks
+    assert tv == pytest.approx(20.0, abs=1e-6)
+
+
+def test_multichannel_tv(mask_ref):
+    """TV on multi-channel map sums across channels."""
+    H, W = mask_ref.shape
+    w = np.zeros((H, W, 2), dtype=np.float32)
+    # Channel 0: constant -> TV = 0
+    w[:, :, 0] = 1.0
+    # Channel 1: random -> TV > 0
+    rng = np.random.default_rng(42)
+    w[:, :, 1] = rng.normal(0, 1, (H, W))
+
+    tv = compute_tv_numpy(w, mask_ref)
+    assert tv > 0
+
+
+# ---- Boundary fraction ----
+
+def test_boundary_fraction_interior_roi(mask_ref):
+    """An ROI entirely in the interior should have low boundary fraction."""
+    H, W = mask_ref.shape
+    roi = np.zeros((H, W), dtype=bool)
+    # Small square in the center
+    roi[H // 2 - 2:H // 2 + 2, W // 2 - 2:W // 2 + 2] = True
+    roi = roi & mask_ref
+
+    bf = compute_boundary_fraction(roi, mask_ref, band_width=3)
+    assert bf < 0.3, f"Interior ROI has high boundary_fraction={bf}"
+
+
+def test_boundary_fraction_edge_roi(mask_ref):
+    """An ROI along the mask edge should have high boundary fraction."""
+    from scipy.ndimage import binary_erosion
+
+    # ROI = mask minus eroded interior -> only the boundary band
+    interior = binary_erosion(mask_ref, iterations=3)
+    roi = mask_ref & ~interior
+
+    bf = compute_boundary_fraction(roi, mask_ref, band_width=3)
+    assert bf > 0.8, f"Edge ROI has low boundary_fraction={bf}"
+
+
+def test_boundary_fraction_empty_roi(mask_ref):
+    """Empty ROI should return 0.0."""
+    roi = np.zeros_like(mask_ref)
+    bf = compute_boundary_fraction(roi, mask_ref)
+    assert bf == 0.0

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_05_trainer.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_05_trainer.py
@@ -1,0 +1,173 @@
+"""
+Phase 1 / Task 1.5 — JAX trainer (logistic + L1 + TV).
+
+Checks:
+- Training converges (objective decreases)
+- Objective log contains all required terms
+- Weight map concentrates in the tail (planted signal region)
+- compute_logits shape and value sanity
+- L1 and TV penalties are active (non-zero in log)
+
+NOTE: Requires JAX. Tests are skipped if JAX is not installed.
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+
+from conftest import GRID_H, GRID_W, N_CHANNELS
+from roi_trainer import TrainResult, compute_logits, train
+
+
+# ---- compute_logits ----
+
+def test_compute_logits_shape(planted_data):
+    """compute_logits returns (N,) array."""
+    X = planted_data["X"]
+    N = X.shape[0]
+    w_full = np.random.randn(GRID_H, GRID_W, N_CHANNELS).astype(np.float32)
+    b = 0.0
+
+    logits = compute_logits(X, w_full, b)
+    assert logits.shape == (N,)
+
+
+def test_compute_logits_bias_shift(planted_data):
+    """Adding bias b should shift all logits by b."""
+    X = planted_data["X"]
+    w_full = np.random.randn(GRID_H, GRID_W, N_CHANNELS).astype(np.float32)
+
+    logits_0 = compute_logits(X, w_full, 0.0)
+    logits_5 = compute_logits(X, w_full, 5.0)
+
+    np.testing.assert_allclose(logits_5 - logits_0, 5.0, atol=1e-5)
+
+
+def test_compute_logits_rejects_wrong_shapes():
+    """3D X or 2D w_full should raise ValueError."""
+    X_bad = np.zeros((10, 32, 32))  # missing channel dim
+    w = np.zeros((32, 32, 1))
+
+    with pytest.raises(ValueError):
+        compute_logits(X_bad, w, 0.0)
+
+
+# ---- Training ----
+
+def test_trainer_converges(planted_data, class_weights, tiny_trainer_config):
+    """Objective should decrease over training."""
+    result = train(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        class_weights=class_weights,
+        lam=1e-3,
+        mu=1e-3,
+        config=tiny_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    assert isinstance(result, TrainResult)
+    assert len(result.objective_log) >= 2
+
+    first_loss = result.objective_log[0]["total_objective"]
+    last_loss = result.objective_log[-1]["total_objective"]
+    assert last_loss < first_loss, (
+        f"Training did not reduce objective: first={first_loss}, last={last_loss}"
+    )
+
+
+def test_objective_log_has_required_terms(planted_data, class_weights, tiny_trainer_config):
+    """Each log entry must contain the terms specified in PLAN.md Section D."""
+    result = train(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        class_weights=class_weights,
+        lam=1e-3,
+        mu=1e-3,
+        config=tiny_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    required_keys = {
+        "logistic_loss_raw", "l1_raw", "tv_raw",
+        "l1_weighted", "tv_weighted", "total_objective",
+    }
+    for entry in result.objective_log:
+        missing = required_keys - set(entry.keys())
+        assert not missing, f"Missing objective log keys: {missing}"
+
+
+def test_weight_map_tail_concentration(planted_data, class_weights, tiny_trainer_config):
+    """
+    BIOLOGICAL PRIOR CHECK (cep290):
+    The weight map magnitude should be higher in the tail region (bottom rows)
+    than in the head region (top rows), since that's where signal was planted.
+    """
+    from conftest import TAIL_START_ROW
+
+    result = train(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        class_weights=class_weights,
+        lam=1e-3,
+        mu=1e-3,
+        config=tiny_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    w_mag = np.sqrt(np.sum(result.w_full ** 2, axis=-1))
+    mask = planted_data["mask_ref"]
+
+    # Mean weight magnitude in tail vs head
+    tail_mask = np.zeros_like(mask)
+    tail_mask[TAIL_START_ROW:, :] = True
+    tail_mask = tail_mask & mask
+    head_mask = np.zeros_like(mask)
+    head_mask[:TAIL_START_ROW, :] = True
+    head_mask = head_mask & mask
+
+    tail_mean = w_mag[tail_mask].mean() if tail_mask.any() else 0
+    head_mean = w_mag[head_mask].mean() if head_mask.any() else 0
+
+    assert tail_mean > head_mean, (
+        f"Weight map should concentrate in tail: tail_mean={tail_mean:.4f}, head_mean={head_mean:.4f}"
+    )
+
+
+def test_train_result_channel_names(planted_data, class_weights, tiny_trainer_config):
+    """TrainResult must carry channel_names (required for Phase 2)."""
+    result = train(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        class_weights=class_weights,
+        lam=1e-3,
+        mu=1e-3,
+        config=tiny_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    assert result.channel_names == ("total_cost",)
+    assert "channel_names" in result.config
+
+
+def test_l1_tv_penalties_nonzero(planted_data, class_weights, tiny_trainer_config):
+    """With non-zero lam and mu, both L1 and TV weighted terms should be > 0."""
+    result = train(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        class_weights=class_weights,
+        lam=1e-2,
+        mu=1e-2,
+        config=tiny_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    last_entry = result.objective_log[-1]
+    assert last_entry["l1_weighted"] > 0, "L1 weighted penalty should be > 0"
+    assert last_entry["tv_weighted"] > 0, "TV weighted penalty should be > 0"

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_06_roi_extraction.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_06_roi_extraction.py
@@ -1,0 +1,93 @@
+"""
+Phase 1 / Task 1.6 — ROI extraction via quantile thresholding.
+
+Checks:
+- ROI is contained within mask_ref
+- area_fraction is in (0, 1) and shrinks with higher quantile
+- n_components is a positive integer
+- For planted tail signal: ROI concentrates in the tail
+- Empty weight maps produce empty ROI
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+
+from conftest import GRID_H, GRID_W, N_CHANNELS, TAIL_START_ROW
+from roi_trainer import extract_roi, train
+
+
+@pytest.fixture
+def trained_result(planted_data, class_weights, tiny_trainer_config):
+    """A trained model on the planted data."""
+    return train(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        class_weights=class_weights,
+        lam=1e-3,
+        mu=1e-3,
+        config=tiny_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+
+def test_roi_inside_mask(trained_result, mask_ref):
+    """ROI must be a subset of mask_ref."""
+    roi, stats = extract_roi(trained_result.w_full, mask_ref, quantile=0.9)
+    assert np.all(roi <= mask_ref), "ROI extends outside mask_ref"
+
+
+def test_roi_area_fraction_range(trained_result, mask_ref):
+    """area_fraction should be between 0 and 1."""
+    roi, stats = extract_roi(trained_result.w_full, mask_ref, quantile=0.9)
+    assert 0.0 < stats["area_fraction"] < 1.0
+
+
+def test_roi_shrinks_with_higher_quantile(trained_result, mask_ref):
+    """Higher quantile threshold should produce a smaller ROI."""
+    _, stats_85 = extract_roi(trained_result.w_full, mask_ref, quantile=0.85)
+    _, stats_95 = extract_roi(trained_result.w_full, mask_ref, quantile=0.95)
+
+    assert stats_95["area_fraction"] <= stats_85["area_fraction"], (
+        f"q=0.95 area={stats_95['area_fraction']} > q=0.85 area={stats_85['area_fraction']}"
+    )
+
+
+def test_roi_n_components_positive(trained_result, mask_ref):
+    """ROI should have at least 1 connected component."""
+    roi, stats = extract_roi(trained_result.w_full, mask_ref, quantile=0.9)
+    assert stats["n_components"] >= 1
+
+
+def test_roi_tail_concentration(trained_result, mask_ref):
+    """
+    BIOLOGICAL PRIOR (cep290): Most ROI pixels should be in the tail.
+    We check that >50% of ROI area is in rows >= TAIL_START_ROW.
+    """
+    roi, stats = extract_roi(trained_result.w_full, mask_ref, quantile=0.9)
+    total_roi = roi.sum()
+    tail_roi = roi[TAIL_START_ROW:, :].sum()
+
+    if total_roi > 0:
+        tail_frac = tail_roi / total_roi
+        assert tail_frac > 0.5, (
+            f"Only {tail_frac:.1%} of ROI is in tail (expected >50%)"
+        )
+
+
+def test_empty_weight_map_gives_empty_roi(mask_ref):
+    """A zero weight map should produce an empty ROI."""
+    w = np.zeros((GRID_H, GRID_W, N_CHANNELS), dtype=np.float32)
+    roi, stats = extract_roi(w, mask_ref, quantile=0.9)
+    assert roi.sum() == 0
+    assert stats["area_fraction"] == 0.0
+    assert stats["n_components"] == 0
+
+
+def test_roi_stats_keys(trained_result, mask_ref):
+    """ROI stats dict must contain all specified keys."""
+    roi, stats = extract_roi(trained_result.w_full, mask_ref, quantile=0.9)
+    required = {"area_fraction", "n_components", "boundary_fraction", "threshold", "quantile"}
+    assert required.issubset(stats.keys()), f"Missing keys: {required - set(stats.keys())}"

--- a/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_07_sweep.py
+++ b/results/mcolon/20260215_roi_discovery_via_ot_feature_maps/tests/test_p1_07_sweep.py
@@ -1,0 +1,160 @@
+"""
+Phase 1 / Task 1.7 — Lambda/mu sweep and deterministic selection.
+
+Checks:
+- Sweep table has one row per (lambda, mu) combination
+- AUROC values are in [0, 1]
+- Pareto knee selection picks a valid (lam, mu) from the grid
+- Epsilon-best selection picks smallest complexity within epsilon of best AUROC
+- Sweep is deterministic (same inputs -> same selection)
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+
+from roi_config import SelectionRule, SweepConfig, TrainerConfig
+from roi_sweep import SweepResult, run_sweep
+
+
+@pytest.fixture
+def tiny_sweep_config():
+    """Minimal sweep config: 2x2 grid, 2 folds."""
+    return SweepConfig(
+        lambda_values=(1e-3, 1e-2),
+        mu_values=(1e-3, 1e-2),
+        n_cv_folds=2,
+        selection_rule=SelectionRule.PARETO_KNEE,
+        pareto_beta=1.0,
+        roi_quantile=0.9,
+    )
+
+
+@pytest.fixture
+def sweep_trainer_config():
+    return TrainerConfig(
+        learn_res=16,
+        output_res=32,
+        learning_rate=1e-2,
+        max_steps=50,
+        convergence_tol=1e-8,
+        log_every=50,
+        random_seed=42,
+    )
+
+
+def test_sweep_table_size(planted_data, tiny_sweep_config, sweep_trainer_config):
+    """Sweep table should have n_lambda * n_mu rows."""
+    result = run_sweep(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        groups=planted_data["groups"],
+        lambda_values=list(tiny_sweep_config.lambda_values),
+        mu_values=list(tiny_sweep_config.mu_values),
+        sweep_config=tiny_sweep_config,
+        trainer_config=sweep_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    expected_rows = len(tiny_sweep_config.lambda_values) * len(tiny_sweep_config.mu_values)
+    assert len(result.sweep_table) == expected_rows
+
+
+def test_sweep_auroc_range(planted_data, tiny_sweep_config, sweep_trainer_config):
+    """All AUROC values should be in [0, 1]."""
+    result = run_sweep(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        groups=planted_data["groups"],
+        lambda_values=list(tiny_sweep_config.lambda_values),
+        mu_values=list(tiny_sweep_config.mu_values),
+        sweep_config=tiny_sweep_config,
+        trainer_config=sweep_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    aurocs = result.sweep_table["auroc_mean"].values
+    assert np.all(aurocs >= 0.0) and np.all(aurocs <= 1.0), (
+        f"AUROC out of range: min={aurocs.min()}, max={aurocs.max()}"
+    )
+
+
+def test_selected_params_in_grid(planted_data, tiny_sweep_config, sweep_trainer_config):
+    """Selected (lam, mu) must come from the sweep grid."""
+    result = run_sweep(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        groups=planted_data["groups"],
+        lambda_values=list(tiny_sweep_config.lambda_values),
+        mu_values=list(tiny_sweep_config.mu_values),
+        sweep_config=tiny_sweep_config,
+        trainer_config=sweep_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    assert result.selected_lam in tiny_sweep_config.lambda_values
+    assert result.selected_mu in tiny_sweep_config.mu_values
+
+
+def test_sweep_determinism(planted_data, tiny_sweep_config, sweep_trainer_config):
+    """Running the same sweep twice should select the same (lam, mu)."""
+    kwargs = dict(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        groups=planted_data["groups"],
+        lambda_values=list(tiny_sweep_config.lambda_values),
+        mu_values=list(tiny_sweep_config.mu_values),
+        sweep_config=tiny_sweep_config,
+        trainer_config=sweep_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    r1 = run_sweep(**kwargs)
+    r2 = run_sweep(**kwargs)
+
+    assert r1.selected_lam == r2.selected_lam
+    assert r1.selected_mu == r2.selected_mu
+
+
+def test_sweep_result_has_selection_metadata(planted_data, tiny_sweep_config, sweep_trainer_config):
+    """SweepResult should carry selection_rule and selection_metadata."""
+    result = run_sweep(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        groups=planted_data["groups"],
+        lambda_values=list(tiny_sweep_config.lambda_values),
+        mu_values=list(tiny_sweep_config.mu_values),
+        sweep_config=tiny_sweep_config,
+        trainer_config=sweep_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    assert result.selection_rule == "pareto_knee"
+    assert "beta" in result.selection_metadata or "rule" in result.selection_metadata
+
+
+def test_planted_signal_gets_good_auroc(planted_data, tiny_sweep_config, sweep_trainer_config):
+    """
+    With a strong planted signal, the sweep should find at least one (lam, mu)
+    with AUROC substantially above chance (0.5).
+    """
+    result = run_sweep(
+        X=planted_data["X"],
+        y=planted_data["y"],
+        mask_ref=planted_data["mask_ref"],
+        groups=planted_data["groups"],
+        lambda_values=list(tiny_sweep_config.lambda_values),
+        mu_values=list(tiny_sweep_config.mu_values),
+        sweep_config=tiny_sweep_config,
+        trainer_config=sweep_trainer_config,
+        channel_names=planted_data["channel_names"],
+    )
+
+    best_auroc = result.sweep_table["auroc_mean"].max()
+    assert best_auroc > 0.65, f"Best AUROC={best_auroc:.3f}, expected >0.65 for planted signal"


### PR DESCRIPTION
Adds TESTPLAN.md, conftest.py with planted-tail-signal fixtures, and
draft test files for Phase 1 tasks 1.1–1.7 (config through sweep).
Still under discussion — structure may change.

https://claude.ai/code/session_01UMGBS1skdwxN7C9koMkesf